### PR TITLE
[API break]: Remove all re-exports

### DIFF
--- a/examples/get_links.rs
+++ b/examples/get_links.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::TryStreamExt;
-use rtnetlink::{
-    new_connection,
-    packet::rtnl::{
-        constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
-        link::nlas::Nla,
-    },
-    Error, Handle,
+use netlink_packet_route::rtnl::{
+    constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
+    link::nlas::Nla,
 };
+use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {

--- a/examples/get_links_async.rs
+++ b/examples/get_links_async.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::TryStreamExt;
-use rtnetlink::{
-    new_connection,
-    packet::rtnl::{
-        constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
-        link::nlas::Nla,
-    },
-    Error, Handle,
+use netlink_packet_route::rtnl::{
+    constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
+    link::nlas::Nla,
 };
+use rtnetlink::{new_connection, Error, Handle};
 
 #[async_std::main]
 async fn main() -> Result<(), ()> {

--- a/examples/get_links_thread_builder.rs
+++ b/examples/get_links_thread_builder.rs
@@ -1,15 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::TryStreamExt;
-
-use rtnetlink::{
-    new_connection,
-    packet::rtnl::{
-        constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
-        link::nlas::Nla,
-    },
-    Error, Handle,
+use netlink_packet_route::rtnl::{
+    constants::{AF_BRIDGE, RTEXT_FILTER_BRVLAN},
+    link::nlas::Nla,
 };
+use rtnetlink::{new_connection, Error, Handle};
 
 async fn do_it(rt: &tokio::runtime::Runtime) -> Result<(), ()> {
     env_logger::init();

--- a/examples/ip_monitor.rs
+++ b/examples/ip_monitor.rs
@@ -3,10 +3,8 @@
 use futures::stream::StreamExt;
 
 use netlink_packet_route::constants::*;
-use rtnetlink::{
-    new_connection,
-    sys::{AsyncSocket, SocketAddr},
-};
+use netlink_proto::sys::{AsyncSocket, SocketAddr};
+use rtnetlink::new_connection;
 
 const fn nl_mgrp(group: u32) -> u32 {
     if group > 31 {

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -4,11 +4,10 @@
 //! changes, listens for said changes and prints the received messages.
 
 use futures::stream::StreamExt;
-
+use netlink_proto::sys::{AsyncSocket, SocketAddr};
 use rtnetlink::{
     constants::{RTMGRP_IPV4_ROUTE, RTMGRP_IPV6_ROUTE},
     new_connection,
-    sys::{AsyncSocket, SocketAddr},
 };
 
 #[tokio::main]

--- a/examples/property_altname.rs
+++ b/examples/property_altname.rs
@@ -1,14 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::TryStreamExt;
-use rtnetlink::{
-    new_connection,
-    packet::{
-        rtnl::link::nlas::{Nla, Prop},
-        LinkMessage,
-    },
-    Error, Handle,
+use netlink_packet_route::{
+    rtnl::link::nlas::{Nla, Prop},
+    LinkMessage,
 };
+use rtnetlink::{new_connection, Error, Handle};
 use std::env;
 
 #[tokio::main]

--- a/src/addr/del.rs
+++ b/src/addr/del.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        AddressMessage, NetlinkMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    AddressMessage, NetlinkMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct AddressDelRequest {
     handle: Handle,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,12 +4,11 @@ use std::io;
 
 use futures::channel::mpsc::UnboundedReceiver;
 
-use crate::{
-    packet::{NetlinkMessage, RtnlMessage},
-    proto::Connection,
-    sys::{protocols::NETLINK_ROUTE, AsyncSocket, SocketAddr},
-    Handle,
-};
+use netlink_packet_route::{NetlinkMessage, RtnlMessage};
+use netlink_proto::sys::{protocols::NETLINK_ROUTE, AsyncSocket, SocketAddr};
+use netlink_proto::Connection;
+
+use crate::Handle;
 
 #[cfg(feature = "tokio_socket")]
 #[allow(clippy::type_complexity)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::packet::{ErrorMessage, NetlinkMessage, RtnlMessage};
+use netlink_packet_route::{ErrorMessage, NetlinkMessage, RtnlMessage};
 
 #[derive(Clone, Eq, PartialEq, Debug, Error)]
 pub enum Error {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -2,13 +2,14 @@
 
 use futures::Stream;
 
+use netlink_packet_route::{NetlinkMessage, RtnlMessage};
+use netlink_proto::{sys::SocketAddr, ConnectionHandle};
+
 use crate::{
-    packet::{NetlinkMessage, RtnlMessage},
     AddressHandle, Error, LinkHandle, NeighbourHandle, QDiscHandle,
     RouteHandle, RuleHandle, TrafficChainHandle, TrafficClassHandle,
     TrafficFilterHandle,
 };
-use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
 #[derive(Clone, Debug)]
 pub struct Handle(ConnectionHandle<RtnlMessage>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@ pub use crate::neighbour::*;
 
 pub mod constants;
 
-pub use netlink_packet_route as packet;
-pub mod proto {
-    pub use netlink_proto::{
-        packet::{NetlinkMessage, NetlinkPayload},
-        Connection, ConnectionHandle, Error,
-    };
-}
-pub use netlink_proto::sys;
+// pub use netlink_packet_route as packet;
+// pub mod proto {
+//    pub use netlink_proto::{
+//        packet::{NetlinkMessage, NetlinkPayload},
+//        Connection, ConnectionHandle, Error,
+//    };
+// }
+// pub use netlink_proto::sys;
 
 mod macros;

--- a/src/link/add.rs
+++ b/src/link/add.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
-use netlink_packet_route::link::nlas::InfoMacVtap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use crate::{
-    packet::{
-        nlas::link::{
-            Info, InfoBond, InfoData, InfoKind, InfoMacVlan, InfoVlan,
-            InfoVxlan, Nla, VethInfo,
-        },
-        LinkMessage, NetlinkMessage, RtnlMessage, IFF_UP, NLM_F_ACK,
-        NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE, NLM_F_REQUEST,
+use futures::stream::StreamExt;
+use netlink_packet_route::{
+    link::nlas::{
+        Info, InfoBond, InfoData, InfoKind, InfoMacVlan, InfoMacVtap, InfoVlan,
+        InfoVxlan, Nla, VethInfo,
     },
-    try_nl, Error, Handle,
+    LinkMessage, NetlinkMessage, RtnlMessage, IFF_UP, NLM_F_ACK, NLM_F_CREATE,
+    NLM_F_EXCL, NLM_F_REPLACE, NLM_F_REQUEST,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct BondAddRequest {
     request: LinkAddRequest,
@@ -560,7 +558,8 @@ impl LinkAddRequest {
     ///
     /// ```rust,no_run
     /// use futures::Future;
-    /// use rtnetlink::{Handle, new_connection, packet::IFF_UP};
+    /// use netlink_packet_route::IFF_UP;
+    /// use rtnetlink::{Handle, new_connection};
     ///
     /// async fn run(handle: Handle) -> Result<(), String> {
     ///     let vlan_id = 100;

--- a/src/link/del.rs
+++ b/src/link/del.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        LinkMessage, NetlinkMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    LinkMessage, NetlinkMessage, RtnlMessage, NLM_F_ACK, NLM_F_REQUEST,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct LinkDelRequest {
     handle: Handle,

--- a/src/link/get.rs
+++ b/src/link/get.rs
@@ -5,13 +5,12 @@ use futures::{
     stream::{StreamExt, TryStream},
     FutureExt,
 };
-
-use crate::{
-    packet::{
-        constants::*, nlas::link::Nla, LinkMessage, NetlinkMessage, RtnlMessage,
-    },
-    try_rtnl, Error, Handle,
+use netlink_packet_route::{
+    nlas::link::Nla, LinkMessage, NetlinkMessage, RtnlMessage, NLM_F_DUMP,
+    NLM_F_REQUEST,
 };
+
+use crate::{try_rtnl, Error, Handle};
 
 pub struct LinkGetRequest {
     handle: Handle,

--- a/src/link/property_add.rs
+++ b/src/link/property_add.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    packet::{
-        nlas::link::{Nla, Prop},
-        LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK,
-        NLM_F_APPEND, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
-    },
-    Error, Handle,
-};
 use futures::stream::StreamExt;
+use netlink_packet_route::{
+    nlas::link::{Nla, Prop},
+    LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK,
+    NLM_F_APPEND, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
+};
+
+use crate::{Error, Handle};
 
 pub struct LinkNewPropRequest {
     handle: Handle,

--- a/src/link/property_del.rs
+++ b/src/link/property_del.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    packet::{
-        nlas::link::{Nla, Prop},
-        LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK,
-        NLM_F_EXCL, NLM_F_REQUEST,
-    },
-    Error, Handle,
-};
 use futures::stream::StreamExt;
+use netlink_packet_route::{
+    nlas::link::{Nla, Prop},
+    LinkMessage, NetlinkMessage, NetlinkPayload, RtnlMessage, NLM_F_ACK,
+    NLM_F_EXCL, NLM_F_REQUEST,
+};
+
+use crate::{Error, Handle};
 
 pub struct LinkDelPropRequest {
     handle: Handle,

--- a/src/link/set.rs
+++ b/src/link/set.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    packet::{
-        nlas::link::Nla, LinkMessage, NetlinkMessage, RtnlMessage, IFF_NOARP,
-        IFF_PROMISC, IFF_UP, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL,
-        NLM_F_REQUEST,
-    },
-    try_nl, Error, Handle,
-};
-use futures::stream::StreamExt;
 use std::os::unix::io::RawFd;
+
+use futures::stream::StreamExt;
+use netlink_packet_route::{
+    nlas::link::Nla, LinkMessage, NetlinkMessage, RtnlMessage, IFF_NOARP,
+    IFF_PROMISC, IFF_UP, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
+};
+
+use crate::{try_nl, Error, Handle};
 
 pub struct LinkSetRequest {
     handle: Handle,

--- a/src/link/test.rs
+++ b/src/link/test.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::TryStreamExt;
+use netlink_packet_route::rtnl::link::{
+    nlas::{Info, InfoKind, Nla},
+    LinkMessage,
+};
 use tokio::runtime::Runtime;
 
-use crate::{
-    new_connection,
-    packet::rtnl::link::{
-        nlas::{Info, InfoKind, Nla},
-        LinkMessage,
-    },
-    Error, LinkHandle,
-};
+use crate::{new_connection, Error, LinkHandle};
 
 const IFACE_NAME: &str = "wg142"; // rand?
 

--- a/src/route/del.rs
+++ b/src/route/del.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage, NLM_F_ACK,
-        NLM_F_REQUEST,
-    },
-    Error, Handle,
+use netlink_packet_route::{
+    NetlinkMessage, NetlinkPayload, RouteMessage, RtnlMessage, NLM_F_ACK,
+    NLM_F_REQUEST,
 };
+
+use crate::{Error, Handle};
 
 pub struct RouteDelRequest {
     handle: Handle,

--- a/src/rule/del.rs
+++ b/src/rule/del.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        NetlinkMessage, RtnlMessage, RuleMessage, NLM_F_ACK, NLM_F_REQUEST,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    NetlinkMessage, RtnlMessage, RuleMessage, NLM_F_ACK, NLM_F_REQUEST,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct RuleDelRequest {
     handle: Handle,

--- a/src/traffic_control/add_filter.rs
+++ b/src/traffic_control/add_filter.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        tc::{self, constants::*},
-        NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
-        TCM_IFINDEX_MAGIC_BLOCK, TC_H_MAKE,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    tc::{self, constants::*},
+    NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
+    TCM_IFINDEX_MAGIC_BLOCK, TC_H_MAKE,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct TrafficFilterNewRequest {
     handle: Handle,
@@ -166,14 +164,12 @@ mod test {
     use std::{fs::File, os::unix::io::AsRawFd, path::Path};
 
     use futures::stream::TryStreamExt;
+    use netlink_packet_route::LinkMessage;
     use nix::sched::{setns, CloneFlags};
     use tokio::runtime::Runtime;
 
     use super::*;
-    use crate::{
-        new_connection, packet::LinkMessage, NetworkNamespace, NETNS_PATH,
-        SELF_NS_PATH,
-    };
+    use crate::{new_connection, NetworkNamespace, NETNS_PATH, SELF_NS_PATH};
 
     const TEST_NS: &str = "netlink_test_filter_ns";
     const TEST_VETH_1: &str = "test_veth_1";

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 use futures::stream::StreamExt;
-
-use crate::{
-    packet::{
-        tc::{constants::*, nlas},
-        NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
-        TC_H_MAKE,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    tc::{constants::*, nlas},
+    NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
+    TC_H_MAKE,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct QDiscNewRequest {
     handle: Handle,
@@ -82,18 +80,15 @@ mod test {
     use std::{fs::File, os::unix::io::AsRawFd, path::Path};
 
     use futures::stream::TryStreamExt;
+    use netlink_packet_route::{
+        rtnl::tc::nlas::Nla::{HwOffload, Kind},
+        LinkMessage, AF_UNSPEC,
+    };
     use nix::sched::{setns, CloneFlags};
     use tokio::runtime::Runtime;
 
     use super::*;
-    use crate::{
-        new_connection,
-        packet::{
-            rtnl::tc::nlas::Nla::{HwOffload, Kind},
-            LinkMessage, AF_UNSPEC,
-        },
-        NetworkNamespace, NETNS_PATH, SELF_NS_PATH,
-    };
+    use crate::{new_connection, NetworkNamespace, NETNS_PATH, SELF_NS_PATH};
 
     const TEST_NS: &str = "netlink_test_qdisc_ns";
     const TEST_DUMMY: &str = "test_dummy";

--- a/src/traffic_control/del_qdisc.rs
+++ b/src/traffic_control/del_qdisc.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT
 use futures::StreamExt;
-
-use crate::{
-    packet::{
-        NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
-    },
-    try_nl, Error, Handle,
+use netlink_packet_route::{
+    NetlinkMessage, RtnlMessage, TcMessage, NLM_F_ACK, NLM_F_REQUEST,
 };
+
+use crate::{try_nl, Error, Handle};
 
 pub struct QDiscDelRequest {
     handle: Handle,

--- a/src/traffic_control/get.rs
+++ b/src/traffic_control/get.rs
@@ -5,14 +5,12 @@ use futures::{
     stream::{StreamExt, TryStream},
     FutureExt,
 };
-
-use crate::{
-    packet::{
-        tc::constants::*, NetlinkMessage, RtnlMessage, TcMessage, NLM_F_DUMP,
-        NLM_F_REQUEST,
-    },
-    try_rtnl, Error, Handle,
+use netlink_packet_route::{
+    tc::constants::*, NetlinkMessage, RtnlMessage, TcMessage, NLM_F_DUMP,
+    NLM_F_REQUEST,
 };
+
+use crate::{try_rtnl, Error, Handle};
 
 pub struct QDiscGetRequest {
     handle: Handle,

--- a/src/traffic_control/handle.rs
+++ b/src/traffic_control/handle.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 
+use netlink_packet_route::{
+    TcMessage, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE,
+};
+
+use crate::Handle;
+
 use super::{
     QDiscDelRequest, QDiscGetRequest, QDiscNewRequest, TrafficChainGetRequest,
     TrafficClassGetRequest, TrafficFilterGetRequest, TrafficFilterNewRequest,
-};
-
-use crate::{
-    packet::{TcMessage, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE},
-    Handle,
 };
 
 pub struct QDiscHandle(Handle);

--- a/src/traffic_control/test.rs
+++ b/src/traffic_control/test.rs
@@ -3,16 +3,13 @@
 use std::process::Command;
 
 use futures::stream::TryStreamExt;
+use netlink_packet_route::{
+    rtnl::tc::nlas::Nla::{Chain, HwOffload, Kind},
+    ErrorMessage, TcMessage, AF_UNSPEC,
+};
 use tokio::runtime::Runtime;
 
-use crate::{
-    new_connection,
-    packet::{
-        rtnl::tc::nlas::Nla::{Chain, HwOffload, Kind},
-        ErrorMessage, TcMessage, AF_UNSPEC,
-    },
-    Error::NetlinkError,
-};
+use crate::{new_connection, Error::NetlinkError};
 
 static TEST_DUMMY_NIC: &str = "netlink-test";
 


### PR DESCRIPTION
Stop re-exporting `netlink_packet_route` and `netlink_proto`.

Test cases and examples updated.