### PR TITLE
feat(ns): implement RAII network namespace guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
 smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 
 [dependencies]
+anyhow = "1.0.26"
 futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"


### PR DESCRIPTION
The guard can let the thread construcing the guard enter its own network namespace, and return to its old network namespace when the guard called Drop.

Signed-off-by: Ji-Xinyou <jerryji0414@outlook.com>