### PR TITLE
New release 0.12.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,14 @@
+# Changelog
+## [0.12.0] - 2023-01-29
+### Breaking changes
+ - Removed these reexports. (2d58a54)
+     * `rtnetlink::packet`
+     * `rtnetlink::proto`
+     * `rtnetlink::sys`
+
+### New features
+ - Allow adding macvtap on a link. (ad1207f)
+ - Support setting priority when adding rules. (b771ffd)
+
+### Bug fixes
+ - Fix ip_monitor example. (b12f061)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
 - Removed these reexports. (2d58a54)
     * `rtnetlink::packet`
     * `rtnetlink::proto`
     * `rtnetlink::sys`

=== New features
 - Allow adding macvtap on a link. (ad1207f)
 - Support setting priority when adding rules. (b771ffd)

=== Bug fixes
 - Fix ip_monitor example. (b12f061)