### PR TITLE
Support route table ID bigger than 255

### DIFF
--- a/examples/add_rule.rs
+++ b/examples/add_rule.rs
@@ -8,30 +8,42 @@ use rtnetlink::{new_connection, Error, Handle};
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     let args: Vec<String> = env::args().collect();
-    if args.len() != 2 {
+    if args.len() != 3 {
         usage();
         return Ok(());
     }
 
-    let dest: Ipv4Network = args[1].parse().unwrap_or_else(|_| {
+    let dst: Ipv4Network = args[1].parse().unwrap_or_else(|_| {
         eprintln!("invalid destination");
+        std::process::exit(1);
+    });
+
+    let table_id: u32 = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("invalid route table ID");
         std::process::exit(1);
     });
 
     let (connection, handle, _) = new_connection().unwrap();
     tokio::spawn(connection);
 
-    if let Err(e) = add_rule(&dest, handle.clone()).await {
+    if let Err(e) = add_rule(&dst, table_id, handle.clone()).await {
         eprintln!("{e}");
+    } else {
+        println!("Route rule has been added for {dst} and lookup {table_id}")
     }
     Ok(())
 }
 
-async fn add_rule(dest: &Ipv4Network, handle: Handle) -> Result<(), Error> {
+async fn add_rule(
+    dst: &Ipv4Network,
+    table_id: u32,
+    handle: Handle,
+) -> Result<(), Error> {
     let rule = handle.rule();
     rule.add()
         .v4()
-        .destination_prefix(dest.ip(), dest.prefix())
+        .destination_prefix(dst.ip(), dst.prefix())
+        .table_id(table_id)
         .execute()
         .await?;
 
@@ -40,16 +52,14 @@ async fn add_rule(dest: &Ipv4Network, handle: Handle) -> Result<(), Error> {
 
 fn usage() {
     eprintln!(
-        "usage:
-    cargo run --example add_rule -- <destination>/<prefix_length> <gateway>
+        "\
+usage: 
+    cargo run --example add_rule -- <destination>/<prefix_length> <table_id> 
 
-Note that you need to run this program as root. Instead of running cargo as root,
-build the example normally:
+Note that you need to run this program as root:
 
-    cd rtnetlink ; cargo build --example add_rule
-
-Then find the binary in the target directory:
-
-    cd ../target/debug/example ; sudo ./add_rule <destination>/<prefix_length> <gateway>"
+    env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \\
+        cargo run --example add_rule -- <destination>/<prefix_length> \
+        <table_id>"
     );
 }

--- a/src/route/add.rs
+++ b/src/route/add.rs
@@ -58,8 +58,21 @@ impl<T> RouteAddRequest<T> {
     /// Sets the route table.
     ///
     /// Default is main route table.
+    #[deprecated(note = "Please use `table_id` instead")]
     pub fn table(mut self, table: u8) -> Self {
         self.message.header.table = table;
+        self
+    }
+
+    /// Sets the route table ID.
+    ///
+    /// Default is main route table.
+    pub fn table_id(mut self, table: u32) -> Self {
+        if table > 255 {
+            self.message.nlas.push(Nla::Table(table));
+        } else {
+            self.message.header.table = table as u8;
+        }
         self
     }
 

--- a/src/rule/add.rs
+++ b/src/rule/add.rs
@@ -57,8 +57,21 @@ impl<T> RuleAddRequest<T> {
     /// Sets the rule table.
     ///
     /// Default is main rule table.
+    #[deprecated(note = "Please use `table_id` instead")]
     pub fn table(mut self, table: u8) -> Self {
         self.message.header.table = table;
+        self
+    }
+
+    /// Sets the rule table ID.
+    ///
+    /// Default is main rule table.
+    pub fn table_id(mut self, table: u32) -> Self {
+        if table > 255 {
+            self.message.nlas.push(Nla::Table(table));
+        } else {
+            self.message.header.table = table as u8;
+        }
         self
     }
 


### PR DESCRIPTION
By using netlink message `RTA_TABLE` instead of
`struct rtmsg.rtm_table`, we can set table ID bigger than 255.

This patch has deprecated the `RuleAddRequest::table` and
`RouteAddRequest::table` in the favor of their `table_id` function.

Example code has been updated to reflect this changes.