### PR TITLE
Remove asserts in TC ( issue #16)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,4 +28,7 @@ pub enum Error {
 
     #[error("Failed to parse a network address (IP and mask): {0:?}/{1:?}")]
     InvalidAddress(Vec<u8>, Vec<u8>),
+
+    #[error("Attempting to set and Invalid NLA: {0}")]
+    InvalidNla(String),
 }

--- a/src/traffic_control/add_filter.rs
+++ b/src/traffic_control/add_filter.rs
@@ -8,7 +8,7 @@ use netlink_packet_route::{
         constants::{
             TCA_ACT_TAB, TCA_EGRESS_REDIR, TC_ACT_STOLEN, TC_H_CLSACT,
             TC_H_MAJ_MASK, TC_H_MIN_EGRESS, TC_H_MIN_INGRESS, TC_H_MIN_MASK,
-            TC_H_ROOT, TC_H_UNSPEC, TC_U32_TERMINAL,
+            TC_H_ROOT, TC_U32_TERMINAL,
         },
     },
     RtnlMessage, TcMessage, TCM_IFINDEX_MAGIC_BLOCK, TC_H_MAKE,
@@ -53,7 +53,6 @@ impl TrafficFilterNewRequest {
     /// Set interface index.
     /// Equivalent to `dev STRING`, dev and block are mutually exlusive.
     pub fn index(mut self, index: i32) -> Self {
-        assert_eq!(self.message.header.index, 0);
         self.message.header.index = index;
         self
     }
@@ -61,7 +60,6 @@ impl TrafficFilterNewRequest {
     /// Set block index.
     /// Equivalent to `block BLOCK_INDEX`.
     pub fn block(mut self, block_index: u32) -> Self {
-        assert_eq!(self.message.header.index, 0);
         self.message.header.index = TCM_IFINDEX_MAGIC_BLOCK as i32;
         self.message.header.parent = block_index;
         self
@@ -71,28 +69,24 @@ impl TrafficFilterNewRequest {
     /// Equivalent to `[ root | ingress | egress | parent CLASSID ]`
     /// command args. They are mutually exlusive.
     pub fn parent(mut self, parent: u32) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = parent;
         self
     }
 
     /// Set parent to root.
     pub fn root(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_ROOT;
         self
     }
 
     /// Set parent to ingress.
     pub fn ingress(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_MAKE!(TC_H_CLSACT, TC_H_MIN_INGRESS);
         self
     }
 
     /// Set parent to egress.
     pub fn egress(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_MAKE!(TC_H_CLSACT, TC_H_MIN_EGRESS);
         self
     }
@@ -100,7 +94,6 @@ impl TrafficFilterNewRequest {
     /// Set priority.
     /// Equivalent to `priority PRIO` or `pref PRIO`.
     pub fn priority(mut self, priority: u16) -> Self {
-        assert_eq!(self.message.header.info & TC_H_MAJ_MASK, 0);
         self.message.header.info =
             TC_H_MAKE!((priority as u32) << 16, self.message.header.info);
         self
@@ -110,7 +103,6 @@ impl TrafficFilterNewRequest {
     /// Equivalent to `protocol PROT`.
     /// Default: ETH_P_ALL 0x0003, see llproto_names at iproute2/lib/ll_proto.c.
     pub fn protocol(mut self, protocol: u16) -> Self {
-        assert_eq!(self.message.header.info & TC_H_MIN_MASK, 0);
         self.message.header.info =
             TC_H_MAKE!(self.message.header.info, protocol as u32);
         self
@@ -139,7 +131,6 @@ impl TrafficFilterNewRequest {
     /// 0 action mirred egress redirect dev dest` You need to set the
     /// `parent` and `protocol` before call redirect.
     pub fn redirect(self, dst_index: u32) -> Self {
-        assert_eq!(self.message.nlas.len(), 0);
         let mut sel_na = tc::u32::Sel::default();
         sel_na.flags = TC_U32_TERMINAL;
         sel_na.nkeys = 1;

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -3,9 +3,7 @@
 use futures::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{
-    tc::constants::{
-        TC_H_INGRESS, TC_H_MAJ_MASK, TC_H_MIN_MASK, TC_H_ROOT, TC_H_UNSPEC,
-    },
+    tc::constants::{TC_H_INGRESS, TC_H_MAJ_MASK, TC_H_MIN_MASK, TC_H_ROOT},
     tc::nlas::Nla,
     RtnlMessage, TcMessage, TC_H_MAKE,
 };
@@ -54,21 +52,18 @@ impl QDiscNewRequest {
 
     /// Set parent to root.
     pub fn root(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_ROOT;
         self
     }
 
     /// Set parent
     pub fn parent(mut self, parent: u32) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = parent;
         self
     }
 
     /// New a ingress qdisc
     pub fn ingress(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_INGRESS;
         self.message.header.handle = 0xffff0000;
         self.message.nlas.push(Nla::Kind("ingress".to_string()));

--- a/src/traffic_control/get.rs
+++ b/src/traffic_control/get.rs
@@ -7,7 +7,7 @@ use futures::{
 };
 use netlink_packet_core::{NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_route::{
-    tc::constants::{TC_H_INGRESS, TC_H_ROOT, TC_H_UNSPEC},
+    tc::constants::{TC_H_INGRESS, TC_H_ROOT},
     RtnlMessage, TcMessage,
 };
 
@@ -54,7 +54,6 @@ impl QDiscGetRequest {
 
     /// Get ingress qdisc
     pub fn ingress(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_INGRESS;
         self
     }
@@ -129,7 +128,6 @@ impl TrafficFilterGetRequest {
 
     /// Set parent to root.
     pub fn root(mut self) -> Self {
-        assert_eq!(self.message.header.parent, TC_H_UNSPEC);
         self.message.header.parent = TC_H_ROOT;
         self
     }


### PR DESCRIPTION
There are 2 commits in this PR:

1. Remove asserts that block reassignment completely. These asserts only checked that some message header value was the default value before doing an assignment a struct member. Reassignment should be allowed, so I've just removed them.
2. Update the u32 filter to return the new `Error::InvalidNla` error rather than panicking when the check condition fails.