### PR TITLE
Route get supports querying the route tables

### DIFF
--- a/examples/get_route.rs
+++ b/examples/get_route.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures::{Stream, TryStreamExt};
+use netlink_packet_route::RouteMessage;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 
 #[tokio::main]
@@ -27,7 +28,12 @@ async fn dump_addresses(
     handle: Handle,
     ip_version: IpVersion,
 ) -> Result<(), Error> {
-    let mut routes = handle.route().get(ip_version).execute();
+    let mut routes: Box<
+        dyn Stream<Item = Result<RouteMessage, rtnetlink::Error>> + Unpin,
+    > = match ip_version {
+        IpVersion::V4 => Box::new(handle.route().get().v4().execute()),
+        IpVersion::V6 => Box::new(handle.route().get().v6().execute()),
+    };
     while let Some(route) = routes.try_next().await? {
         println!("{route:?}");
     }

--- a/examples/get_route_to.rs
+++ b/examples/get_route_to.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+use std::net::IpAddr;
+
+use futures::{Stream, TryStreamExt};
+use netlink_packet_route::RouteMessage;
+use rtnetlink::{new_connection, Error, Handle};
+
+#[tokio::main]
+async fn main() {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let destinations = [
+        "8.8.8.8".parse().unwrap(),
+        "127.0.0.8".parse().unwrap(),
+        "2001:4860:4860::8888".parse().unwrap(),
+        "::1".parse().unwrap(),
+    ];
+    for dest in destinations {
+        println!("getting best route to {}", dest);
+        if let Err(e) = dump_route_to(handle.clone(), dest).await {
+            eprintln!("{e}");
+        }
+        println!();
+    }
+}
+
+async fn dump_route_to(handle: Handle, dest: IpAddr) -> Result<(), Error> {
+    let mut routes: Box<
+        dyn Stream<Item = Result<RouteMessage, rtnetlink::Error>> + Unpin,
+    > = match dest {
+        IpAddr::V4(v4) => Box::new(handle.route().get().v4().to(v4).execute()),
+        IpAddr::V6(v6) => Box::new(handle.route().get().v6().to(v6).execute()),
+    };
+    if let Some(route) = routes.try_next().await? {
+        println!("{route:?}");
+    }
+    Ok(())
+}

--- a/src/route/get.rs
+++ b/src/route/get.rs
@@ -1,22 +1,34 @@
 // SPDX-License-Identifier: MIT
 
+use std::{
+    marker::PhantomData,
+    net::{Ipv4Addr, Ipv6Addr},
+};
+
 use futures::{
     future::{self, Either},
-    stream::{StreamExt, TryStream},
-    FutureExt,
+    stream::StreamExt,
+    FutureExt, Stream,
 };
 
 use netlink_packet_core::{NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
 use netlink_packet_route::{
-    RouteMessage, RtnlMessage, AF_INET, AF_INET6, RTN_UNSPEC, RTPROT_UNSPEC,
-    RT_SCOPE_UNIVERSE, RT_TABLE_UNSPEC,
+    route::Nla, RouteMessage, RtnlMessage, AF_INET, AF_INET6, RTN_UNSPEC,
+    RTPROT_UNSPEC, RT_SCOPE_UNIVERSE, RT_TABLE_UNSPEC,
 };
 
 use crate::{try_rtnl, Error, Handle};
 
-pub struct RouteGetRequest {
+pub struct RouteGetRequest<T = ()> {
     handle: Handle,
     message: RouteMessage,
+    // There are two ways to retrieve routes: we can either dump them
+    // all and filter the result, or if we already know the destination
+    // of the route we're looking for, we can just retrieve
+    // that one. If `dump` is `true`, all the routes are fetched.
+    // Otherwise, only the best route to the destination is fetched.
+    dump: bool,
+    _phantom: PhantomData<T>,
 }
 
 /// Internet Protocol (IP) version.
@@ -37,10 +49,9 @@ impl IpVersion {
     }
 }
 
-impl RouteGetRequest {
-    pub(crate) fn new(handle: Handle, ip_version: IpVersion) -> Self {
+impl<T> RouteGetRequest<T> {
+    pub(crate) fn new(handle: Handle) -> Self {
         let mut message = RouteMessage::default();
-        message.header.address_family = ip_version.family();
 
         // As per rtnetlink(7) documentation, setting the following
         // fields to 0 gets us all the routes from all the tables
@@ -58,21 +69,118 @@ impl RouteGetRequest {
         message.header.table = RT_TABLE_UNSPEC;
         message.header.protocol = RTPROT_UNSPEC;
 
-        RouteGetRequest { handle, message }
+        RouteGetRequest {
+            handle,
+            message,
+            dump: true,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Sets the output interface index.
+    pub fn output_interface(mut self, index: u32) -> Self {
+        self.message.nlas.push(Nla::Oif(index));
+        self
     }
 
     pub fn message_mut(&mut self) -> &mut RouteMessage {
         &mut self.message
     }
+}
 
-    pub fn execute(self) -> impl TryStream<Ok = RouteMessage, Error = Error> {
+impl RouteGetRequest<()> {
+    pub fn v4(mut self) -> RouteGetRequest<Ipv4Addr> {
+        self.message.header.address_family = AF_INET as u8;
+        RouteGetRequest::<Ipv4Addr> {
+            _phantom: PhantomData::<Ipv4Addr>,
+            handle: self.handle,
+            message: self.message,
+            dump: self.dump,
+        }
+    }
+
+    pub fn v6(mut self) -> RouteGetRequest<Ipv6Addr> {
+        self.message.header.address_family = AF_INET6 as u8;
+        RouteGetRequest::<Ipv6Addr> {
+            _phantom: PhantomData::<Ipv6Addr>,
+            handle: self.handle,
+            message: self.message,
+            dump: self.dump,
+        }
+    }
+}
+
+impl RouteGetRequest<Ipv4Addr> {
+    /// Get the best route to this destination
+    pub fn to(mut self, ip: Ipv4Addr) -> Self {
+        self.message.nlas.push(Nla::Destination(ip.octets().into()));
+        self.message.header.destination_prefix_length = 32;
+        self.dump = false;
+        self
+    }
+
+    pub fn from(mut self, ip: Ipv6Addr) -> Self {
+        self.message.nlas.push(Nla::Source(ip.octets().into()));
+        self.message.header.source_prefix_length = 32;
+        self
+    }
+
+    pub fn execute(self) -> impl Stream<Item = Result<RouteMessage, Error>> {
         let RouteGetRequest {
             mut handle,
             message,
+            dump,
+            _phantom,
         } = self;
 
         let mut req = NetlinkMessage::from(RtnlMessage::GetRoute(message));
-        req.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+        req.header.flags = if dump {
+            NLM_F_REQUEST | NLM_F_DUMP
+        } else {
+            NLM_F_REQUEST
+        };
+
+        match handle.request(req) {
+            Ok(response) => Either::Left(
+                response
+                    .map(move |msg| Ok(try_rtnl!(msg, RtnlMessage::NewRoute))),
+            ),
+            Err(e) => Either::Right(
+                future::err::<RouteMessage, Error>(e).into_stream(),
+            ),
+        }
+    }
+}
+
+impl RouteGetRequest<Ipv6Addr> {
+    /// Get the best route to this destination
+    pub fn to(mut self, ip: Ipv6Addr) -> Self {
+        self.message.nlas.push(Nla::Destination(ip.octets().into()));
+        self.message.header.destination_prefix_length = 32;
+        self.dump = false;
+        self
+    }
+
+    pub fn from(mut self, ip: Ipv6Addr) -> Self {
+        self.message.nlas.push(Nla::Source(ip.octets().into()));
+        self.message.header.source_prefix_length = 32;
+        self
+    }
+
+    pub fn execute(self) -> impl Stream<Item = Result<RouteMessage, Error>> {
+        let RouteGetRequest {
+            mut handle,
+            message,
+            dump,
+            _phantom,
+        } = self;
+
+        let mut req = NetlinkMessage::from(RtnlMessage::GetRoute(message));
+        req.header.flags = if dump {
+            NLM_F_REQUEST | NLM_F_DUMP
+        } else {
+            NLM_F_REQUEST
+        };
 
         match handle.request(req) {
             Ok(response) => Either::Left(

--- a/src/route/handle.rs
+++ b/src/route/handle.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    Handle, IpVersion, RouteAddRequest, RouteDelRequest, RouteGetRequest,
-};
+use crate::{Handle, RouteAddRequest, RouteDelRequest, RouteGetRequest};
 use netlink_packet_route::RouteMessage;
 
 pub struct RouteHandle(Handle);
@@ -14,8 +12,8 @@ impl RouteHandle {
 
     /// Retrieve the list of routing table entries (equivalent to `ip route
     /// show`)
-    pub fn get(&self, ip_version: IpVersion) -> RouteGetRequest {
-        RouteGetRequest::new(self.0.clone(), ip_version)
+    pub fn get(&self) -> RouteGetRequest {
+        RouteGetRequest::new(self.0.clone())
     }
 
     /// Add an routing table entry (equivalent to `ip route add`)


### PR DESCRIPTION
Closes #22

This MR adds support for querying the route tables for the best route to a given destination, which as of now only supports dumping all route tables. 

### Design 

The idea behind the design is pretty simple and inspired by what route::add and neighbour::get do: the user gets a `RouteRequest<()>` from the handle, which they must specialize into either a `RouteRequest<Ipv4Addr>` or `RouteRequest<Ipv6Addr>` by calling `v4()` or `v6()` before being able to call `execute()`. Once specialized, the user can optionally add a destination address, but only of the same address family as the generic parameter (you can't put a ipv6 destination in `RouteRequest<Ipv4Addr>`). Doing this will turn the request into a lookup request instead of dump request.

Unfortunately, this design introduces a change to the API for the user, and will require a version bump. 

It also adds a new `examples/get_route_to.rs` example to showcase this use case.

###  `execute()` opaque return type

While writing this PR, I faced a lot of troubles related to opaque types. Like all other requests in this crate, `RouteRequest::execute()` used to return a opaque `impl TryStream<Ok = RouteMessage, Error = Error>`. This becomes a problem if the user tries to handle ipv4 and ipv6 in a single code path, like so:

```rust
/// Dump either Ipv4 or Ipv6 routes
async fn dump_all_routes(
    handle: Handle,
    ip_version: IpVersion,
) -> Result<(), Error> {
    let mut routes = match ip_version {
        IpVersion::V4 => handle.route().get().v4().execute(),
        IpVersion::V6 => handle.route().get().v6().execute(),
    };
    while let Some(route) = routes.try_next().await? {
        println!("{route:?}");
    }
    Ok(())
}
``` 

Because `RouteRequest` is now generic, the return type of `RouteRequest<Ipv4Addr>` and `RouteRequest<Ipv6Addr>` are no longer the same concrete type, even though they have the exact same opaque type signature. Because of this, the two match arms differ in type, and `routes` cannot have a valid type.

The only way I found around this problem is dynamic dispatch, which means asking the user to turn the concrete opaque type returned by `execute()` into a `Box<dyn TryStream<...>>` in both match arms. But for that the user has to write the full type signature of the trait, including the associated type `Steam::Item` which is erased in the returned opaque type, and this unprovable constraint makes rustc refuse to compile.  

I solved this by changing the opaque type returned by `execute()` into a simpler opaque `impl Stream<Item = Result<...>>`, which [automatically implements `TryStream`](https://docs.rs/futures/latest/futures/stream/trait.TryStream.html#impl-TryStream-for-S) anyway, so this is transparent for the user.

The final solution is 

```rust 
    let mut routes: Box<
        dyn Stream<Item = Result<RouteMessage, rtnetlink::Error>> + Unpin,
    > = match ip_version {
        IpVersion::V4 => Box::new(handle.route().get().v4().execute()),
        IpVersion::V6 => Box::new(handle.route().get().v6().execute()),
    };
    while let Some(route) = routes.try_next().await? {
        println!("{route:?}");
    }
```  

which I'm not super happy about, because it asks the user to write a complicated dyn type.

Another solution would have been to make `RouteRequest` an exception, and have `execute()` return a `Box<Stream<Item = ...>`. 