### PR TITLE
New release 0.13.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,19 @@
 # Changelog
+## [0.13.0] - 2023-07-10
+### Breaking changes
+ - `TrafficFilterNewRequest::u32()` changed to return `Result`. (b7f8c73)
+ - `TrafficFilterNewRequest::redirect() changed to return `Result`. (b7f8c73)
+ - Deprecated `RouteAddRequest::table` in the favor of
+   `RouteAddRequest::table_id` in order to support table ID bigger than 255.
+   (0a8eddd)
+
+### New features
+ - Support route table ID bigger than 255. (0a8eddd)
+ - Support creating xfrm tunnel. (5252908)
+
+### Bug fixes
+ - Removed assers. (e6bcf3e)
+
 ## [0.12.0] - 2023-01-29
 ### Breaking changes
  - Removed these reexports. (2d58a54)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
 - `TrafficFilterNewRequest::u32()` changed to return `Result`. (b7f8c73)
 - `TrafficFilterNewRequest::redirect() changed to return `Result`. (b7f8c73)
 - Deprecated `RouteAddRequest::table` in the favor of
   `RouteAddRequest::table_id` in order to support table ID bigger than 255.
   (0a8eddd)

=== New features
 - Support route table ID bigger than 255. (0a8eddd)
 - Support creating xfrm tunnel. (5252908)

=== Bug fixes
 - Removed assers. (e6bcf3e)