### PR TITLE
expose route priority for RouteAddRequest

### DIFF
--- a/src/route/add.rs
+++ b/src/route/add.rs
@@ -58,6 +58,14 @@ impl<T> RouteAddRequest<T> {
         self
     }
 
+    /// Sets the route priority (metric)
+    pub fn priority(mut self, priority: u32) -> Self {
+        self.message
+            .attributes
+            .push(RouteAttribute::Priority(priority));
+        self
+    }
+
     /// Sets the route table.
     ///
     /// Default is main route table.


### PR DESCRIPTION
### What
- expose route priority (metric) for `RouteAddRequest`

Tested by adding `.priority(...)` to [`add_route.rs`](https://github.com/rust-netlink/rtnetlink/blob/main/examples/add_route.rs) example:

```diff
// SPDX-License-Identifier: MIT

use std::env;

use ipnetwork::Ipv4Network;
use rtnetlink::{new_connection, Error, Handle};

const TEST_TABLE_ID: u32 = 254;

#[tokio::main]
async fn main() -> Result<(), ()> {
    let args: Vec<String> = env::args().collect();
    if args.len() != 3 {
        usage();
        return Ok(());
    }

    let dest: Ipv4Network = args[1].parse().unwrap_or_else(|_| {
        eprintln!("invalid destination");
        std::process::exit(1);
    });
    let gateway: Ipv4Network = args[2].parse().unwrap_or_else(|_| {
        eprintln!("invalid gateway");
        std::process::exit(1);
    });

    let (connection, handle, _) = new_connection().unwrap();
    tokio::spawn(connection);

    if let Err(e) = add_route(&dest, &gateway, handle.clone()).await {
        eprintln!("{e}");
    } else {
        println!("Route has been added to table {TEST_TABLE_ID}");
    }
    Ok(())
}

async fn add_route(
    dest: &Ipv4Network,
    gateway: &Ipv4Network,
    handle: Handle,
) -> Result<(), Error> {
    let route = handle.route();
    route
        .add()
        .v4()
        .destination_prefix(dest.ip(), dest.prefix())
+       .priority(700)
        .gateway(gateway.ip())
        .table_id(TEST_TABLE_ID)
        .execute()
        .await?;
    Ok(())
}

fn usage() {
    eprintln!(
        "\
usage:
    cargo run --example add_route -- <destination>/<prefix_length> <gateway>
Note that you need to run this program as root:
    env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' \\
        cargo run --example add_route -- <destination>/<prefix_length> \
        <gateway>"
    );
}
```

Running w/ `route_add <ip>/<cidr> <ip>`
```sh
~>ip r
unicast <ip>/<cidr> via <ip> dev <dev> proto static scope global metric 700 
```
