### PR TITLE
Provide the ability to set the underlying link ID when adding xfrm link types

### DIFF
--- a/examples/create_macvlan.rs
+++ b/examples/create_macvlan.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), String> {
     }
     let link_name = &args[1];
     let mac: Option<Vec<u8>> = if args.len() == 3 {
-        let mac_address_arg = (&args[2]).to_string();
+        let mac_address_arg = args[2].to_string();
         let mac_address = MacAddr::from_str(mac_address_arg.as_str())
             .map_err(|e| format!("{e}"))?;
         Some(mac_address.as_bytes().into())

--- a/src/link/add.rs
+++ b/src/link/add.rs
@@ -729,11 +729,30 @@ impl LinkAddRequest {
     /// Create xfrm tunnel
     /// This is equivalent to `ip link add name NAME type xfrm if_id NUMBER`,
     /// The NUMBER is a XFRM if_id which may be connected to IPsec policy
+    #[deprecated(note = "Please use `xfrmtun_link` instead")]
     pub fn xfrmtun(self, name: String, ifid: u32) -> Self {
         self.name(name)
             .link_info(
                 InfoKind::Xfrm,
                 Some(InfoData::Xfrm(vec![InfoXfrm::IfId(ifid)])),
+            )
+            .up()
+    }
+
+    /// Create xfrm tunnel
+    /// This is equivalent to `ip link add name NAME type xfrm if_id NUMBER dev
+    /// LINK`. The NUMBER is a XFRM if_id which may be connected to IPsec
+    /// policy. The LINK is the underlying link ID to attach the tunnel to,
+    /// but instead of specifying a link name (`LINK`), we specify a link
+    /// index. A LINK of `0` can be used to specify `NONE`.
+    pub fn xfrmtun_link(self, name: String, ifid: u32, link: u32) -> Self {
+        self.name(name)
+            .link_info(
+                InfoKind::Xfrm,
+                Some(InfoData::Xfrm(vec![
+                    InfoXfrm::IfId(ifid),
+                    InfoXfrm::Link(link),
+                ])),
             )
             .up()
     }

--- a/src/link/test.rs
+++ b/src/link/test.rs
@@ -32,7 +32,7 @@ fn create_get_delete_macvlan() {
     const MACVLAN_IFACE_NAME: &str = "mvlan1";
     const LOWER_DEVICE_IDX: u32 = 2;
     const MACVLAN_MODE: u32 = 4; // bridge
-    let mac_address = &vec![2u8, 0, 0, 0, 0, 1];
+    let mac_address = [2u8, 0, 0, 0, 0, 1];
 
     let rt = Runtime::new().unwrap();
     let handle = rt.block_on(_create_macvlan(
@@ -49,7 +49,7 @@ fn create_get_delete_macvlan() {
         rt.block_on(_get_iface(&mut handle, MACVLAN_IFACE_NAME.to_owned()));
     assert!(msg.is_ok());
     assert!(has_nla(
-        &msg.as_ref().unwrap(),
+        msg.as_ref().unwrap(),
         &LinkAttribute::LinkInfo(vec![
             LinkInfo::Kind(InfoKind::MacVlan),
             LinkInfo::Data(InfoData::MacVlan(vec![
@@ -62,15 +62,15 @@ fn create_get_delete_macvlan() {
         ])
     ));
     assert!(has_nla(
-        &msg.as_ref().unwrap(),
+        msg.as_ref().unwrap(),
         &LinkAttribute::IfName(MACVLAN_IFACE_NAME.to_string())
     ));
     assert!(has_nla(
-        &msg.as_ref().unwrap(),
+        msg.as_ref().unwrap(),
         &LinkAttribute::Link(LOWER_DEVICE_IDX)
     ));
     assert!(has_nla(
-        &msg.as_ref().unwrap(),
+        msg.as_ref().unwrap(),
         &LinkAttribute::Address(mac_address.to_vec())
     ));
 

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -10,7 +10,7 @@ use nix::{
     },
     unistd::{fork, ForkResult},
 };
-use std::{option::Option, os::fd::BorrowedFd, path::Path, process::exit};
+use std::{os::fd::BorrowedFd, path::Path, process::exit};
 
 // if "only" smol or smol+tokio were enabled, we use smol because
 // it doesn't require an active tokio runtime - just to be sure.

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -83,9 +83,7 @@ mod test {
 
     use super::*;
     use crate::{new_connection, NetworkNamespace, NETNS_PATH, SELF_NS_PATH};
-    use netlink_packet_route::{
-        link::LinkMessage, tc::TcAttribute, AddressFamily,
-    };
+    use netlink_packet_route::{link::LinkMessage, AddressFamily};
 
     const TEST_NS: &str = "netlink_test_qdisc_ns";
     const TEST_DUMMY: &str = "test_dummy";


### PR DESCRIPTION
I would like to change the LinkAddRequest.xfrmtun() function to allow specifying the underlying interface link ID in addition to the if_id parameter. There isn't a convenient way of doing this without digging deeply into the created request with message_mut().