### PR TITLE
[WIP] support NHFLAGS [ onlink | pervasive ]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
-netlink-packet-utils = { version = "0.5" }
-netlink-packet-route = { version = "0.17" }
+netlink-packet-utils = { version = "0.5.2" }
+netlink-packet-route = { git = "https://github.com/liuxu623/netlink-packet-route.git", tag = "v0.17.2" }
 netlink-packet-core = { version = "0.7" }
 netlink-proto = { default-features = false, version = "0.11" }
 nix = { version = "0.26.1", default-features = false, features = ["fs", "mount", "sched", "signal"] }
-tokio = { version = "1.0.1", features = ["rt"], optional = true}
+tokio = { version = "1.0.1", features = ["rt"], optional = true }
 async-global-executor = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"
 ipnetwork = "0.18.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
-async-std = { version = "1.9.0", features = ["attributes"]}
+async-std = { version = "1.9.0", features = ["attributes"] }

--- a/src/route/add.rs
+++ b/src/route/add.rs
@@ -11,7 +11,7 @@ use netlink_packet_core::{
     NLM_F_REQUEST,
 };
 use netlink_packet_route::{
-    nlas::route::Nla, RouteMessage, RtnlMessage, AF_INET, AF_INET6,
+    nlas::route::Nla, RouteMessage, RtnlMessage, RouteFlags, AF_INET, AF_INET6,
     RTN_UNICAST, RTPROT_STATIC, RT_SCOPE_UNIVERSE, RT_TABLE_MAIN,
 };
 
@@ -97,6 +97,12 @@ impl<T> RouteAddRequest<T> {
     /// Default is unicast route kind.
     pub fn kind(mut self, kind: u8) -> Self {
         self.message.header.kind = kind;
+        self
+    }
+
+    /// Sets the route flags.
+    pub fn flags(mut self, flag: RouteFlags) -> Self {
+        self.message.header.flags = flag;
         self
     }
 


### PR DESCRIPTION
like `ip r add default dev eth0 via 169.254.1.1 onlink`

depend on https://github.com/rust-netlink/netlink-packet-route/pull/51