### PR TITLE
Update to nix 0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ netlink-packet-utils = { version = "0.5" }
 netlink-packet-route = { version = "0.17" }
 netlink-packet-core = { version = "0.7" }
 netlink-proto = { default-features = false, version = "0.11" }
-nix = { version = "0.26.1", default-features = false, features = ["fs", "mount", "sched", "signal"] }
+nix = { version = "0.27.1", default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }
 

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -10,7 +10,7 @@ use nix::{
     },
     unistd::{fork, ForkResult},
 };
-use std::{option::Option, path::Path, process::exit};
+use std::{option::Option, os::fd::BorrowedFd, path::Path, process::exit};
 
 // if "only" smol or smol+tokio were enabled, we use smol because
 // it doesn't require an active tokio runtime - just to be sure.
@@ -329,7 +329,10 @@ impl NetworkNamespace {
         }
 
         setns_flags.insert(CloneFlags::CLONE_NEWNET);
-        if let Err(e) = nix::sched::setns(fd, setns_flags) {
+        if let Err(e) = nix::sched::setns(
+            unsafe { BorrowedFd::borrow_raw(fd) },
+            setns_flags,
+        ) {
             log::error!("setns error: {}", e);
             let err_msg = format!("setns error: {e}");
             let _ = nix::unistd::unlink(ns_path);

--- a/src/traffic_control/add_filter.rs
+++ b/src/traffic_control/add_filter.rs
@@ -162,7 +162,7 @@ impl TrafficFilterNewRequest {
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, os::unix::io::AsRawFd, path::Path};
+    use std::{fs::File, os::fd::AsFd, path::Path};
 
     use futures::stream::TryStreamExt;
     use netlink_packet_route::LinkMessage;
@@ -193,7 +193,7 @@ mod test {
             // entry new ns
             let ns_path = Path::new(NETNS_PATH);
             let file = File::open(ns_path.join(path)).unwrap();
-            setns(file.as_raw_fd(), CloneFlags::CLONE_NEWNET).unwrap();
+            setns(file.as_fd(), CloneFlags::CLONE_NEWNET).unwrap();
 
             Self {
                 path: path.to_string(),
@@ -205,7 +205,7 @@ mod test {
     impl Drop for Netns {
         fn drop(&mut self) {
             println!("exit ns: {}", self.path);
-            setns(self.last.as_raw_fd(), CloneFlags::CLONE_NEWNET).unwrap();
+            setns(self.last.as_fd(), CloneFlags::CLONE_NEWNET).unwrap();
 
             let ns_path = Path::new(NETNS_PATH).join(&self.path);
             nix::mount::umount2(&ns_path, nix::mount::MntFlags::MNT_DETACH)

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -73,7 +73,7 @@ impl QDiscNewRequest {
 
 #[cfg(test)]
 mod test {
-    use std::{fs::File, os::unix::io::AsRawFd, path::Path};
+    use std::{fs::File, os::fd::AsFd, path::Path};
 
     use futures::stream::TryStreamExt;
     use nix::sched::{setns, CloneFlags};
@@ -106,7 +106,7 @@ mod test {
             // entry new ns
             let ns_path = Path::new(NETNS_PATH);
             let file = File::open(ns_path.join(path)).unwrap();
-            setns(file.as_raw_fd(), CloneFlags::CLONE_NEWNET).unwrap();
+            setns(file.as_fd(), CloneFlags::CLONE_NEWNET).unwrap();
 
             Self {
                 path: path.to_string(),
@@ -118,7 +118,7 @@ mod test {
     impl Drop for Netns {
         fn drop(&mut self) {
             println!("exit ns: {}", self.path);
-            setns(self.last.as_raw_fd(), CloneFlags::CLONE_NEWNET).unwrap();
+            setns(self.last.as_fd(), CloneFlags::CLONE_NEWNET).unwrap();
 
             let ns_path = Path::new(NETNS_PATH).join(&self.path);
             nix::mount::umount2(&ns_path, nix::mount::MntFlags::MNT_DETACH)


### PR DESCRIPTION
Nix 0.27 now uses the OwnedFd/BorrowedFd API from Rust 1.63.

The `setns` call needs a BorrowedFd, while we only have a raw fd. We could either create a OwnedFd or a BorrowedFd from the open done in `unshare_processing`, but the OwnedFd would close on drop, while there is no close in the current code, so I simply created a BorrowedFd on the fly. I'm not sure whether the missing close is a bug or not.