### PR TITLE
Specify rust-version in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/rust-netlink/rtnetlink"
 description = "manipulate linux networking resources via netlink"
+rust-version = "1.66.1"
 
 [features]
 test_as_root = []


### PR DESCRIPTION
Specify the rust-version in the cargo manfiest as 1.66.1.

The current reason for the the requirement is the use if `std::os::fd::RawFd` in `netlink-packet-route` `0.17.1` (link_xdp.rs).