### PR TITLE
FreeBSD support

### DIFF
--- a/examples/add_netns.rs
+++ b/examples/add_netns.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(not(target_os = "freebsd"))]
 use rtnetlink::NetworkNamespace;
 use std::env;
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[tokio::main]
 async fn main() -> Result<(), String> {
     env_logger::init();

--- a/examples/add_netns_async.rs
+++ b/examples/add_netns_async.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(not(target_os = "freebsd"))]
 use rtnetlink::NetworkNamespace;
 use std::env;
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[async_std::main]
 async fn main() -> Result<(), String> {
     env_logger::init();

--- a/examples/add_tc_qdisc_ingress.rs
+++ b/examples/add_tc_qdisc_ingress.rs
@@ -4,6 +4,10 @@ use std::env;
 
 use rtnetlink::new_connection;
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     env_logger::init();

--- a/examples/del_netns.rs
+++ b/examples/del_netns.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(not(target_os = "freebsd"))]
 use rtnetlink::NetworkNamespace;
 use std::env;
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[tokio::main]
 async fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();

--- a/examples/del_netns_async.rs
+++ b/examples/del_netns_async.rs
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: MIT
 
+#[cfg(not(target_os = "freebsd"))]
 use rtnetlink::NetworkNamespace;
 use std::env;
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[async_std::main]
 async fn main() -> Result<(), String> {
     let args: Vec<String> = env::args().collect();

--- a/examples/get_links.rs
+++ b/examples/get_links.rs
@@ -7,6 +7,10 @@ use netlink_packet_route::{
 };
 use rtnetlink::{new_connection, Error, Handle};
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     env_logger::init();
@@ -90,6 +94,7 @@ async fn dump_links(handle: Handle) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(not(target_os = "freebsd"))]
 async fn dump_bridge_filter_info(handle: Handle) -> Result<(), Error> {
     let mut links = handle
         .link()

--- a/examples/get_links_async.rs
+++ b/examples/get_links_async.rs
@@ -7,6 +7,10 @@ use netlink_packet_route::{
 };
 use rtnetlink::{new_connection, Error, Handle};
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 #[async_std::main]
 async fn main() -> Result<(), ()> {
     env_logger::init();
@@ -90,6 +94,7 @@ async fn dump_links(handle: Handle) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(not(target_os = "freebsd"))]
 async fn dump_bridge_filter_info(handle: Handle) -> Result<(), Error> {
     let mut links = handle
         .link()

--- a/examples/get_links_thread_builder.rs
+++ b/examples/get_links_thread_builder.rs
@@ -5,8 +5,11 @@ use netlink_packet_route::{
     link::{LinkAttribute, LinkExtentMask},
     AddressFamily,
 };
-use rtnetlink::{new_connection, Error, Handle};
+#[cfg(not(target_os = "freebsd"))]
+use rtnetlink::new_connection;
+use rtnetlink::{Error, Handle};
 
+#[cfg(not(target_os = "freebsd"))]
 async fn do_it(rt: &tokio::runtime::Runtime) -> Result<(), ()> {
     env_logger::init();
     let (connection, handle, _) = new_connection().unwrap();
@@ -89,6 +92,7 @@ async fn dump_links(handle: Handle) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(not(target_os = "freebsd"))]
 async fn dump_bridge_filter_info(handle: Handle) -> Result<(), Error> {
     let mut links = handle
         .link()
@@ -109,6 +113,10 @@ async fn dump_bridge_filter_info(handle: Handle) -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(target_os = "freebsd")]
+fn main() -> () {}
+
+#[cfg(not(target_os = "freebsd"))]
 fn main() -> Result<(), String> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_io()

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -6,9 +6,11 @@ use netlink_packet_route::RouteNetlinkMessage;
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
 use crate::{
-    AddressHandle, Error, LinkHandle, NeighbourHandle, QDiscHandle,
-    RouteHandle, RuleHandle, TrafficChainHandle, TrafficClassHandle,
-    TrafficFilterHandle,
+    AddressHandle, Error, LinkHandle, NeighbourHandle, RouteHandle, RuleHandle,
+};
+#[cfg(not(target_os = "freebsd"))]
+use crate::{
+    QDiscHandle, TrafficChainHandle, TrafficClassHandle, TrafficFilterHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -71,24 +73,28 @@ impl Handle {
 
     /// Create a new handle, specifically for traffic control qdisc requests
     /// (equivalent to `tc qdisc show` commands)
+    #[cfg(not(target_os = "freebsd"))]
     pub fn qdisc(&self) -> QDiscHandle {
         QDiscHandle::new(self.clone())
     }
 
     /// Create a new handle, specifically for traffic control class requests
     /// (equivalent to `tc class show dev <interface_name>` commands)
+    #[cfg(not(target_os = "freebsd"))]
     pub fn traffic_class(&self, ifindex: i32) -> TrafficClassHandle {
         TrafficClassHandle::new(self.clone(), ifindex)
     }
 
     /// Create a new handle, specifically for traffic control filter requests
     /// (equivalent to `tc filter show dev <interface_name>` commands)
+    #[cfg(not(target_os = "freebsd"))]
     pub fn traffic_filter(&self, ifindex: i32) -> TrafficFilterHandle {
         TrafficFilterHandle::new(self.clone(), ifindex)
     }
 
     /// Create a new handle, specifically for traffic control chain requests
     /// (equivalent to `tc chain show dev <interface_name>` commands)
+    #[cfg(not(target_os = "freebsd"))]
     pub fn traffic_chain(&self, ifindex: i32) -> TrafficChainHandle {
         TrafficChainHandle::new(self.clone(), ifindex)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@
 mod handle;
 pub use crate::handle::*;
 
+#[cfg(not(target_os = "freebsd"))]
 mod ns;
+#[cfg(not(target_os = "freebsd"))]
 pub use crate::ns::*;
 
 mod errors;
@@ -29,7 +31,9 @@ pub use crate::rule::*;
 mod connection;
 pub use crate::connection::*;
 
+#[cfg(not(target_os = "freebsd"))]
 mod traffic_control;
+#[cfg(not(target_os = "freebsd"))]
 pub use crate::traffic_control::*;
 
 mod neighbour;

--- a/src/neighbour/add.rs
+++ b/src/neighbour/add.rs
@@ -51,6 +51,7 @@ impl NeighbourAddRequest {
         }
     }
 
+    #[cfg(not(target_os = "freebsd"))]
     pub(crate) fn new_bridge(handle: Handle, index: u32, lla: &[u8]) -> Self {
         let mut message = NeighbourMessage::default();
 

--- a/src/neighbour/handle.rs
+++ b/src/neighbour/handle.rs
@@ -23,6 +23,7 @@ impl NeighbourHandle {
         NeighbourAddRequest::new(self.0.clone(), index, destination)
     }
 
+    #[cfg(not(target_os = "freebsd"))]
     /// Add a new fdb entry (equivalent to `bridge fdb add`)
     pub fn add_bridge(&self, index: u32, lla: &[u8]) -> NeighbourAddRequest {
         NeighbourAddRequest::new_bridge(self.0.clone(), index, lla)


### PR DESCRIPTION
rtnetlink has 2 problems building on FreeBSD:
* no support for Linux namespaces and traffic control, addressed in first commit
* lack of `AddressFamily::Bridge` in `netlink-packet-route`, addressed in second commit

I originally thought about hiding namespaces and traffic control behind a `ns` feature, what do you think?

That second point brings me back to my original suggestion of having enum values defined once, regardless of target platform support.