### PR TITLE
feat: option to specify netlink header flags in `LinkAddRequest`

### DIFF
--- a/src/link/add.rs
+++ b/src/link/add.rs
@@ -537,7 +537,7 @@ impl VxlanAddRequest {
 pub struct LinkAddRequest {
     handle: Handle,
     message: LinkMessage,
-    replace: bool,
+    extra_flags: u16,
 }
 
 /// A quality-of-service mapping between the internal priority `from` to the
@@ -559,7 +559,7 @@ impl LinkAddRequest {
         LinkAddRequest {
             handle,
             message: LinkMessage::default(),
-            replace: false,
+            extra_flags: NLM_F_EXCL | NLM_F_CREATE,
         }
     }
 
@@ -568,12 +568,11 @@ impl LinkAddRequest {
         let LinkAddRequest {
             mut handle,
             message,
-            replace,
+            extra_flags,
         } = self;
         let mut req =
             NetlinkMessage::from(RouteNetlinkMessage::NewLink(message));
-        let replace = if replace { NLM_F_REPLACE } else { NLM_F_EXCL };
-        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | replace | NLM_F_CREATE;
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | extra_flags;
 
         let mut response = handle.request(req)?;
         while let Some(message) = response.next().await {
@@ -771,7 +770,15 @@ impl LinkAddRequest {
     /// Replace existing matching link.
     pub fn replace(self) -> Self {
         Self {
-            replace: true,
+            extra_flags: NLM_F_REPLACE | (self.extra_flags & (!NLM_F_EXCL)),
+            ..self
+        }
+    }
+
+    /// Overrides the flags used on request execution
+    pub fn flags(self, flags: u16) -> Self {
+        Self {
+            extra_flags: flags,
             ..self
         }
     }


### PR DESCRIPTION
We're trying to enable vlan_filtering on an existing bridge, the equivalant of 

    # ip link set dev br0 type bridge vlan_filtering 1

After some back and forth manipulating the message and strace'ing iproute2 to eliminate all the differences, I got to the point where the only difference was that the flags used by iproute2 were `NLM_F_REQUEST|NLM_F_ACK`. 

With this change, we are now able to successfully enable vlan filtering on a bridge like so:
```
    let (link_index, _) = find_link(&handle, "br0".to_string())
        .await
        .unwrap()
        .unwrap();

    let mut req: LinkAddRequest = handle.link().add().flags(0);
    let mut msg = req.message_mut();
    msg.header.index = link_index;
    msg.attributes.push(LinkAttribute::LinkInfo(vec![
        LinkInfo::Kind(InfoKind::Bridge),
        LinkInfo::Data(InfoData::Bridge(vec![InfoBridge::VlanFiltering(1)])),
    ]));
    req.execute().await.unwrap();
```

## Questions

* Does modifying `LinkAddRequest` to support sending these types of requests make sense? Perhaps a new `Link...Request` might be more appropriate
* Might exposing this functionality in other request types also be helpful?

