### PR TITLE
feat(route): support get route by destination address

### DIFF
--- a/examples/get_route_to.rs
+++ b/examples/get_route_to.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    println!("dumping specific destination route for IPv4");
+    let dest_str = "127.0.0.1";
+    let dest: Ipv4Addr = dest_str.parse().expect("Invalid IP address format");
+    if let Err(e) = dump_route_to(handle.clone(), IpAddr::V4(dest)).await {
+        eprintln!("{e}");
+    }
+    println!();
+
+    println!("dumping specific destination route for IPv6");
+    let dest_str = "::1";
+    let dest: Ipv6Addr = dest_str.parse().expect("Invalid IP address format");
+    if let Err(e) = dump_route_to(handle.clone(), IpAddr::V6(dest)).await {
+        eprintln!("{e}");
+    }
+    println!();
+
+    Ok(())
+}
+
+async fn dump_route_to(
+    handle: Handle,
+    destination: IpAddr,
+) -> Result<(), Error> {
+    let mut routes = handle.route().get_to(destination).execute_to();
+    while let Some(route) = routes.try_next().await? {
+        println!("{route:?}");
+    }
+    Ok(())
+}

--- a/src/route/handle.rs
+++ b/src/route/handle.rs
@@ -4,6 +4,7 @@ use crate::{
     Handle, IpVersion, RouteAddRequest, RouteDelRequest, RouteGetRequest,
 };
 use netlink_packet_route::route::RouteMessage;
+use std::net::IpAddr;
 
 pub struct RouteHandle(Handle);
 
@@ -26,5 +27,9 @@ impl RouteHandle {
     /// Delete the given routing table entry (equivalent to `ip route del`)
     pub fn del(&self, route: RouteMessage) -> RouteDelRequest {
         RouteDelRequest::new(self.0.clone(), route)
+    }
+    
+    pub fn get_to(&self, destination: IpAddr) -> RouteGetRequest {
+        RouteGetRequest::new_to(self.0.clone(), destination)
     }
 }


### PR DESCRIPTION
Closes #22

This PR supports querying routes for specific addresses without breaking API, achieved by adding a new API. 