### PR TITLE
`netlink-*` packages re-exported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,12 @@
 
 #![allow(clippy::module_inception)]
 
+pub use netlink_packet_core as packet_core;
+pub use netlink_packet_route as packet_route;
+pub use netlink_packet_utils as packet_utils;
+pub use netlink_proto as proto;
+pub use netlink_sys as sys;
+
 mod handle;
 pub use crate::handle::*;
 


### PR DESCRIPTION
Closes #28.
Re-exported `netlink-*` dependencies in `lib.rs` file to avoid dependency versioning hell while using package.
It seems like the original issue maintainer has abandoned it, so I decided to step in and fix this (as at least for now it seems to be super easy).
Let me know if there are anything else I could fix about this issue.