### PR TITLE
add_neighbour example: set required link_local_address

### DIFF
--- a/examples/add_neighbour.rs
+++ b/examples/add_neighbour.rs
@@ -80,6 +80,7 @@ build the example normally:
 
 Then find the binary in the target directory:
 
-    cd ../target/debug/example ; sudo ./add_neighbour <link_name> <ip_address>"
+    cd ../target/debug/example ;
+    sudo ./add_neighbour <link_name> <ip_address> <mac>"
     );
 }

--- a/examples/add_neighbour.rs
+++ b/examples/add_neighbour.rs
@@ -36,7 +36,9 @@ async fn main() -> Result<(), ()> {
     let (connection, handle, _) = new_connection().unwrap();
     tokio::spawn(connection);
 
-    if let Err(e) = add_neighbour(link_name, ip, link_local_address, handle.clone()).await {
+    if let Err(e) =
+        add_neighbour(link_name, ip, link_local_address, handle.clone()).await
+    {
         eprintln!("{e}");
     }
     Ok(())


### PR DESCRIPTION
Adding (or replacing) a neighbour fails for me without setting a link local address. First, I receive error 22 and all reattempts receive error 17. 

This e.g. also shows in the example. After building `cargo build --example add_neighbour` as a normal user I get the following when running it as root:
```
# ./add_neighbour eth0 10.17.31.55                                                                                                         
Received a netlink error message Invalid argument (os error 22)                                                                                                                     
# ./add_neighbour eth0 10.17.31.55                                                                                                         
Received a netlink error message File exists (os error 17) 
```

This is also in line with `ip` which also requires setting a link local address for me:
```
# ip neigh add 10.17.31.55 dev eth0
Error: No link layer address given.
```

Hence, I assume this is the correct behaviour. I don't know whether the example worked at some point and the behaviour in the kernel changed. I have `cargo 1.78.0 (54d8815d0 2024-03-26)`, I run everything on a Debian 12 with kernel `6.1.76` and `ip -V` reports `iproute2-6.1.0, libbpf 1.1.0`.

To fix the example, I adjusted it in this MR to also get a link local address as argument:
```
# ./add_neighbour eth0 10.17.31.55 56:78:90:ab:cd:ef
Done
```

