### PR TITLE
Clean up public exports

### DIFF
--- a/src/addr/mod.rs
+++ b/src/addr/mod.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
 mod add;
-pub use self::add::*;
-
 mod del;
-pub use self::del::*;
-
 mod get;
-pub use self::get::*;
+mod handle;
+
+pub use self::add::AddressAddRequest;
+pub use self::del::AddressDelRequest;
+pub use self::get::AddressGetRequest;
+pub use self::handle::AddressHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,40 +11,51 @@ pub use netlink_packet_utils as packet_utils;
 pub use netlink_proto as proto;
 pub use netlink_sys as sys;
 
+mod addr;
+mod connection;
+pub mod constants;
+mod errors;
 mod handle;
-pub use crate::handle::*;
-
+mod link;
+mod macros;
+mod neighbour;
 #[cfg(not(target_os = "freebsd"))]
 mod ns;
-#[cfg(not(target_os = "freebsd"))]
-pub use crate::ns::*;
-
-mod errors;
-pub use crate::errors::*;
-
-mod link;
-pub use crate::link::*;
-
-mod addr;
-pub use crate::addr::*;
-
 mod route;
-pub use crate::route::*;
-
 mod rule;
-pub use crate::rule::*;
-
-mod connection;
-pub use crate::connection::*;
-
 #[cfg(not(target_os = "freebsd"))]
 mod traffic_control;
+
+pub use crate::addr::{
+    AddressAddRequest, AddressDelRequest, AddressGetRequest, AddressHandle,
+};
+#[cfg(feature = "tokio_socket")]
+pub use crate::connection::new_connection;
+pub use crate::connection::new_connection_with_socket;
+pub use crate::errors::Error;
+pub use crate::handle::Handle;
+pub use crate::link::{
+    BondAddRequest, BondPortSetRequest, LinkAddRequest, LinkDelPropRequest,
+    LinkDelRequest, LinkGetRequest, LinkHandle, LinkNewPropRequest,
+    LinkSetRequest, QosMapping, VxlanAddRequest,
+};
+pub use crate::neighbour::{
+    NeighbourAddRequest, NeighbourDelRequest, NeighbourGetRequest,
+    NeighbourHandle,
+};
 #[cfg(not(target_os = "freebsd"))]
-pub use crate::traffic_control::*;
-
-mod neighbour;
-pub use crate::neighbour::*;
-
-pub mod constants;
-
-mod macros;
+pub use crate::ns::{NetworkNamespace, NETNS_PATH, NONE_FS, SELF_NS_PATH};
+pub use crate::route::{
+    IpVersion, RouteAddRequest, RouteDelRequest, RouteGetRequest, RouteHandle,
+    RouteMessageBuilder,
+};
+pub use crate::rule::{
+    RuleAddRequest, RuleDelRequest, RuleGetRequest, RuleHandle,
+};
+#[cfg(not(target_os = "freebsd"))]
+pub use crate::traffic_control::{
+    QDiscDelRequest, QDiscGetRequest, QDiscHandle, QDiscNewRequest,
+    TrafficChainGetRequest, TrafficChainHandle, TrafficClassGetRequest,
+    TrafficClassHandle, TrafficFilterGetRequest, TrafficFilterHandle,
+    TrafficFilterNewRequest,
+};

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -1,28 +1,24 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
 mod add;
-pub use self::add::*;
-
 mod del;
-pub use self::del::*;
-
 mod get;
-pub use self::get::*;
-
-mod set;
-pub use self::set::*;
-
-mod set_bond_port;
-pub use self::set_bond_port::*;
-
+mod handle;
 mod property_add;
-pub use self::property_add::*;
-
 mod property_del;
-pub use self::property_del::*;
+mod set;
+mod set_bond_port;
+
+pub use self::add::{
+    BondAddRequest, LinkAddRequest, QosMapping, VxlanAddRequest,
+};
+pub use self::del::LinkDelRequest;
+pub use self::get::LinkGetRequest;
+pub use self::handle::LinkHandle;
+pub use self::property_add::LinkNewPropRequest;
+pub use self::property_del::LinkDelPropRequest;
+pub use self::set::LinkSetRequest;
+pub use self::set_bond_port::BondPortSetRequest;
 
 #[cfg(test)]
 mod test;

--- a/src/neighbour/mod.rs
+++ b/src/neighbour/mod.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
-mod get;
-pub use self::get::*;
-
 mod add;
-pub use self::add::*;
-
 mod del;
-pub use self::del::*;
+mod get;
+mod handle;
+
+pub use self::add::NeighbourAddRequest;
+pub use self::del::NeighbourDelRequest;
+pub use self::get::NeighbourGetRequest;
+pub use self::handle::NeighbourHandle;

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
 mod add;
-pub use self::add::*;
-
-mod del;
-pub use self::del::*;
-
-mod get;
-pub use self::get::*;
-
 mod builder;
+mod del;
+mod get;
+mod handle;
+
+pub use self::add::RouteAddRequest;
 pub use self::builder::RouteMessageBuilder;
+pub use self::del::RouteDelRequest;
+pub use self::get::{IpVersion, RouteGetRequest};
+pub use self::handle::RouteHandle;

--- a/src/rule/mod.rs
+++ b/src/rule/mod.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
 mod add;
-pub use self::add::*;
-
 mod del;
-pub use self::del::*;
-
 mod get;
-pub use self::get::*;
+mod handle;
+
+pub use self::add::RuleAddRequest;
+pub use self::del::RuleDelRequest;
+pub use self::get::RuleGetRequest;
+pub use self::handle::RuleHandle;

--- a/src/traffic_control/mod.rs
+++ b/src/traffic_control/mod.rs
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: MIT
 
-mod handle;
-pub use self::handle::*;
-
-mod get;
-pub use self::get::*;
-
-mod add_qdisc;
-pub use self::add_qdisc::*;
-
-mod del_qdisc;
-pub use self::del_qdisc::*;
-
 mod add_filter;
-pub use self::add_filter::*;
-
+mod add_qdisc;
+mod del_qdisc;
+mod get;
+mod handle;
 #[cfg(test)]
 mod test;
+
+pub use self::add_filter::TrafficFilterNewRequest;
+pub use self::add_qdisc::QDiscNewRequest;
+pub use self::del_qdisc::QDiscDelRequest;
+pub use self::get::{
+    QDiscGetRequest, TrafficChainGetRequest, TrafficClassGetRequest,
+    TrafficFilterGetRequest,
+};
+pub use self::handle::{
+    QDiscHandle, TrafficChainHandle, TrafficClassHandle, TrafficFilterHandle,
+};


### PR DESCRIPTION
Instead of `pub use foo::*`, we should be explicitly define our public
types.