### PR TITLE
[examples] Added few vrf examples following #PR59

### DIFF
--- a/examples/create_vrf.rs
+++ b/examples/create_vrf.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+use rtnetlink::new_connection;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+    handle
+        .link()
+        .add()
+        .vrf("my-vrf-1".into(), 666)
+        .execute()
+        .await
+        .map_err(|e| format!("{e}"))
+}

--- a/examples/get_vrf_table_id.rs
+++ b/examples/get_vrf_table_id.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use netlink_packet_route::link::{InfoData, InfoVrf, LinkAttribute, LinkInfo};
+use rtnetlink::{new_connection, Error, Handle};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let vrf_name = &args[1];
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    get_vrf_table_id(handle.clone(), vrf_name.to_string())
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+async fn get_vrf_table_id(handle: Handle, name: String) -> Result<(), Error> {
+    let mut links = handle.link().get().match_name(name.clone()).execute();
+    let msg = if let Some(msg) = links.try_next().await? {
+        msg
+    } else {
+        eprintln!("[get_vrf_table_id] : no link with name {name} found");
+        return Ok(());
+    };
+
+    // We should have received only one message
+    assert!(links.try_next().await?.is_none());
+
+    for nla in msg.attributes.into_iter() {
+        if let LinkAttribute::LinkInfo(lnkinfs) = nla {
+            for lnkinf in lnkinfs.into_iter() {
+                if let LinkInfo::Data(InfoData::Vrf(vrfinfs)) = lnkinf {
+                    for vrfinf in vrfinfs.iter() {
+                        if let InfoVrf::TableId(table_id) = vrfinf {
+                            println!("VRF:{} TABLE_ID:{:?}", name, table_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example get_vrf_table_id -- <vrf_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example get_vrf_table_id
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./get_vrf_table_id <vrf_name>"
+    );
+}

--- a/examples/set_link_no_vrf.rs
+++ b/examples/set_link_no_vrf.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let link_name = &args[1];
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    set_link_no_vrf(handle, link_name.to_string())
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+async fn set_link_no_vrf(handle: Handle, name: String) -> Result<(), Error> {
+    let mut links = handle.link().get().match_name(name.clone()).execute();
+    if let Some(link) = links.try_next().await? {
+        handle
+            .link()
+            .set(link.header.index)
+            .nocontroller()
+            .execute()
+            .await?
+    } else {
+        println!("no link link {name} found");
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example set_link_no_vrf -- <link_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example set_link_no_vrf
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./set_link_no_vrf <link_name>"
+    );
+}

--- a/examples/set_link_up.rs
+++ b/examples/set_link_up.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let link_name = &args[1];
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    set_link_up(handle, link_name.to_string())
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+async fn set_link_up(handle: Handle, name: String) -> Result<(), Error> {
+    let mut links = handle.link().get().match_name(name.clone()).execute();
+    if let Some(link) = links.try_next().await? {
+        handle.link().set(link.header.index).up().execute().await?
+    } else {
+        println!("no link link {name} found");
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example set_link_up -- <link_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example set_link_up
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./set_link_up <link_name>"
+    );
+}

--- a/examples/set_link_vrf.rs
+++ b/examples/set_link_vrf.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        usage();
+        return Ok(());
+    }
+    let link_name = &args[1];
+    let ctrl_name = &args[2];
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    set_link_vrf(handle.clone(), link_name.to_string(), ctrl_name.to_string())
+        .await
+        .map_err(|e| format!("{e}"))
+}
+
+async fn set_link_vrf(
+    handle: Handle,
+    name: String,
+    controller: String,
+) -> Result<(), Error> {
+    let mut ctrls =
+        handle.link().get().match_name(controller.clone()).execute();
+    let mut links = handle.link().get().match_name(name.clone()).execute();
+
+    if let Some(ctrl) = ctrls.try_next().await? {
+        if let Some(link) = links.try_next().await? {
+            handle
+                .link()
+                .set(link.header.index)
+                .controller(ctrl.header.index)
+                .execute()
+                .await?
+        } else {
+            println!("no link link {name} found");
+        }
+    } else {
+        println!("no vrf vrf {controller} found");
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example set_link_vrf -- <link_name> <vrf_name>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd netlink-ip ; cargo build --example set_link_vrf 
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./set_link_vrf <link_name> <vrf_name>"
+    );
+}


### PR DESCRIPTION
Added few examples following [VRF PR-59](https://github.com/rust-netlink/rtnetlink/pull/59) corresponding to `vrf` manipulation primitives.

Question:
Is there a better way to fetch `table_id` using `vrf name` rather than "crawling `LinkAttributes->LinkInfo->InfoData->InfoVrf->TableId` ?

Anyhow, many thanks for your awesome work on `rust-netlink` !