### PR TITLE
Add support for `ip addr add <IP> peer <PEER_IP>`

### DIFF
--- a/src/addr/handle.rs
+++ b/src/addr/handle.rs
@@ -25,8 +25,15 @@ impl AddressHandle {
         index: u32,
         address: IpAddr,
         prefix_len: u8,
+        peer_address: Option<IpAddr>,
     ) -> AddressAddRequest {
-        AddressAddRequest::new(self.0.clone(), index, address, prefix_len)
+        AddressAddRequest::new(
+            self.0.clone(),
+            index,
+            address,
+            prefix_len,
+            peer_address,
+        )
     }
 
     /// Delete the given address


### PR DESCRIPTION
This pull request adds support for specifying a peer IP address when adding an IP address. If a peer address is provided, it will be used instead of the local IP for the IFA_ADDRESS attribute.