### PR TITLE
Added set parent and ingress to QDiscDelRequest

### DIFF
--- a/src/traffic_control/del_qdisc.rs
+++ b/src/traffic_control/del_qdisc.rs
@@ -2,7 +2,10 @@
 
 use futures::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
-use netlink_packet_route::{tc::TcMessage, RouteNetlinkMessage};
+use netlink_packet_route::{
+    tc::{TcAttribute, TcHandle, TcMessage},
+    RouteNetlinkMessage,
+};
 
 use crate::{try_nl, Error, Handle};
 
@@ -38,5 +41,33 @@ impl QDiscDelRequest {
     /// Return a mutable reference to the request
     pub fn message_mut(&mut self) -> &mut TcMessage {
         &mut self.message
+    }
+
+    /// Set handle
+    pub fn handle(mut self, major: u16, minor: u16) -> Self {
+        self.message.header.handle = TcHandle { major, minor };
+        self
+    }
+
+    /// Set parent to root
+    pub fn root(mut self) -> Self {
+        self.message.header.parent = TcHandle::ROOT;
+        self
+    }
+
+    /// Set parent
+    pub fn parent(mut self, parent: u32) -> Self {
+        self.message.header.parent = parent.into();
+        self
+    }
+
+    /// Set ingress qdisc
+    pub fn ingress(mut self) -> Self {
+        self.message.header.parent = TcHandle::INGRESS;
+        self.message.header.handle = TcHandle::from(0xffff0000);
+        self.message
+            .attributes
+            .push(TcAttribute::Kind("ingress".to_string()));
+        self
     }
 }


### PR DESCRIPTION
Extend the `QDiscDelRequest` struct with additional methods (`parent`, `root`, and `ingress`) to enable functionality equivalent to the CLI command `qdisc del dev INTERFACE ingress`. This change allows for more granular control when deleting qdiscs, specifically targeting ingress qdiscs on network interfaces. For example:

```rust
handle.qdisc().del(index).ingress().execute().await;
```

now directly maps to the command:

```bash
qdisc del dev INTERFACE ingress
```