### PR TITLE
Update dependencies, most notably to netlink-packet-route 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
 netlink-packet-utils = { version = "0.5" }
-netlink-packet-route = { version = "0.20" }
+netlink-packet-route = { version = "0.21" }
 netlink-packet-core = { version = "0.7" }
 netlink-proto = { default-features = false, version = "0.11" }
-nix = { version = "0.27.1", default-features = false, features = ["fs", "mount", "sched", "signal"] }
+nix = { version = "0.29.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }
 
 [dev-dependencies]
-env_logger = "0.10.0"
-ipnetwork = "0.18.0"
+env_logger = "0.11.0"
+ipnetwork = "0.20.0"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
 async-std = { version = "1.9.0", features = ["attributes"]}
 macaddr = "1.0"

--- a/src/link/bond.rs
+++ b/src/link/bond.rs
@@ -4,7 +4,9 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use crate::{
     link::LinkMessageBuilder,
-    packet_route::link::{BondMode, InfoBond, InfoData, InfoKind},
+    packet_route::link::{
+        BondArpValidate, BondMode, InfoBond, InfoData, InfoKind,
+    },
 };
 
 ///
@@ -116,7 +118,7 @@ impl LinkMessageBuilder<LinkBond> {
     /// Adds the `arp_validate` attribute to the bond
     /// This is equivalent to `ip link add name NAME type bond arp_validate
     /// ARP_VALIDATE`.
-    pub fn arp_validate(self, arp_validate: u32) -> Self {
+    pub fn arp_validate(self, arp_validate: BondArpValidate) -> Self {
         self.append_info_data(InfoBond::ArpValidate(arp_validate))
     }
 

--- a/src/link/vxlan.rs
+++ b/src/link/vxlan.rs
@@ -87,7 +87,7 @@ impl LinkMessageBuilder<LinkVxlan> {
     /// This function takes an IPv4 address
     /// WARNING: only one between `remote` and `group` can be present.
     pub fn group(self, addr: std::net::Ipv4Addr) -> Self {
-        self.append_info_data(InfoVxlan::Group(addr.octets().to_vec()))
+        self.append_info_data(InfoVxlan::Group(addr))
     }
 
     /// Adds the `group` attribute to the VXLAN
@@ -96,7 +96,7 @@ impl LinkMessageBuilder<LinkVxlan> {
     /// This function takes an IPv6 address
     /// WARNING: only one between `remote` and `group` can be present.
     pub fn group6(self, addr: std::net::Ipv6Addr) -> Self {
-        self.append_info_data(InfoVxlan::Group6(addr.octets().to_vec()))
+        self.append_info_data(InfoVxlan::Group6(addr))
     }
 
     /// Adds the `remote` attribute to the VXLAN
@@ -128,7 +128,7 @@ impl LinkMessageBuilder<LinkVxlan> {
     /// IPADDR`, local IPADDR - specifies the source IP address to use in
     /// outgoing packets. This function takes an IPv4 address.
     pub fn local(self, addr: std::net::Ipv4Addr) -> Self {
-        self.append_info_data(InfoVxlan::Local(addr.octets().to_vec()))
+        self.append_info_data(InfoVxlan::Local(addr))
     }
 
     /// Adds the `local` attribute to the VXLAN
@@ -136,7 +136,7 @@ impl LinkMessageBuilder<LinkVxlan> {
     /// IPADDR`, local IPADDR - specifies the source IP address to use in
     /// outgoing packets. This function takes an IPv6 address.
     pub fn local6(self, addr: std::net::Ipv6Addr) -> Self {
-        self.append_info_data(InfoVxlan::Local6(addr.octets().to_vec()))
+        self.append_info_data(InfoVxlan::Local6(addr))
     }
 
     /// Adds the `tos` attribute to the VXLAN


### PR DESCRIPTION
Minor API break: LinkMessageBuilder::arp_validate now requires an argument of type BondArpValidate instead of u32 as before.