### PR TITLE
impl Debug, Clone for all requests and handles

### DIFF
--- a/src/route/add.rs
+++ b/src/route/add.rs
@@ -13,6 +13,7 @@ use crate::{try_nl, Error, Handle};
 
 /// A request to create a new route. This is equivalent to the `ip route add`
 /// commands.
+#[derive(Debug, Clone)]
 pub struct RouteAddRequest<T = IpAddr> {
     handle: Handle,
     message: RouteMessage,

--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -13,6 +13,7 @@ use netlink_packet_route::{
     AddressFamily,
 };
 
+#[derive(Debug, Clone)]
 pub struct RouteMessageBuilder<T = IpAddr> {
     message: RouteMessage,
     _phantom: PhantomData<T>,

--- a/src/route/del.rs
+++ b/src/route/del.rs
@@ -8,6 +8,7 @@ use netlink_packet_route::{route::RouteMessage, RouteNetlinkMessage};
 
 use crate::{Error, Handle};
 
+#[derive(Debug, Clone)]
 pub struct RouteDelRequest {
     handle: Handle,
     message: RouteMessage,

--- a/src/route/get.rs
+++ b/src/route/get.rs
@@ -13,6 +13,7 @@ use netlink_packet_route::{
 
 use crate::{try_rtnl, Error, Handle};
 
+#[derive(Debug, Clone)]
 pub struct RouteGetRequest {
     handle: Handle,
     message: RouteMessage,

--- a/src/route/handle.rs
+++ b/src/route/handle.rs
@@ -3,6 +3,7 @@
 use crate::{Handle, RouteAddRequest, RouteDelRequest, RouteGetRequest};
 use netlink_packet_route::route::RouteMessage;
 
+#[derive(Debug, Clone)]
 pub struct RouteHandle(Handle);
 
 impl RouteHandle {

--- a/src/rule/add.rs
+++ b/src/rule/add.rs
@@ -21,6 +21,7 @@ use crate::{try_nl, Error, Handle};
 
 /// A request to create a new rule. This is equivalent to the `ip rule add`
 /// command.
+#[derive(Debug, Clone)]
 pub struct RuleAddRequest<T = ()> {
     handle: Handle,
     message: RuleMessage,

--- a/src/rule/del.rs
+++ b/src/rule/del.rs
@@ -6,6 +6,7 @@ use netlink_packet_route::{rule::RuleMessage, RouteNetlinkMessage};
 
 use crate::{try_nl, Error, Handle};
 
+#[derive(Debug, Clone)]
 pub struct RuleDelRequest {
     handle: Handle,
     message: RuleMessage,

--- a/src/rule/get.rs
+++ b/src/rule/get.rs
@@ -14,6 +14,7 @@ use netlink_packet_route::{
 
 use crate::{try_rtnl, Error, Handle, IpVersion};
 
+#[derive(Debug, Clone)]
 pub struct RuleGetRequest {
     handle: Handle,
     message: RuleMessage,

--- a/src/rule/handle.rs
+++ b/src/rule/handle.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use netlink_packet_route::rule::RuleMessage;
 
+#[derive(Debug, Clone)]
 pub struct RuleHandle(Handle);
 
 impl RuleHandle {

--- a/src/traffic_control/add_filter.rs
+++ b/src/traffic_control/add_filter.rs
@@ -17,6 +17,7 @@ use crate::{
     try_nl, Error, Handle,
 };
 
+#[derive(Debug, Clone)]
 pub struct TrafficFilterNewRequest {
     handle: Handle,
     message: TcMessage,

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -11,6 +11,7 @@ use crate::{
     try_nl, Error, Handle,
 };
 
+#[derive(Debug, Clone)]
 pub struct QDiscNewRequest {
     handle: Handle,
     message: TcMessage,

--- a/src/traffic_control/del_qdisc.rs
+++ b/src/traffic_control/del_qdisc.rs
@@ -6,6 +6,7 @@ use netlink_packet_route::{tc::TcMessage, RouteNetlinkMessage};
 
 use crate::{try_nl, Error, Handle};
 
+#[derive(Debug, Clone)]
 pub struct QDiscDelRequest {
     handle: Handle,
     message: TcMessage,

--- a/src/traffic_control/get.rs
+++ b/src/traffic_control/get.rs
@@ -13,6 +13,7 @@ use netlink_packet_route::{
 
 use crate::{try_rtnl, Error, Handle};
 
+#[derive(Debug, Clone)]
 pub struct QDiscGetRequest {
     handle: Handle,
     message: TcMessage,
@@ -60,6 +61,7 @@ impl QDiscGetRequest {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficClassGetRequest {
     handle: Handle,
     message: TcMessage,
@@ -94,6 +96,7 @@ impl TrafficClassGetRequest {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficFilterGetRequest {
     handle: Handle,
     message: TcMessage,
@@ -135,6 +138,7 @@ impl TrafficFilterGetRequest {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficChainGetRequest {
     handle: Handle,
     message: TcMessage,

--- a/src/traffic_control/handle.rs
+++ b/src/traffic_control/handle.rs
@@ -9,6 +9,7 @@ use crate::Handle;
 use netlink_packet_core::{NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE};
 use netlink_packet_route::tc::TcMessage;
 
+#[derive(Debug, Clone)]
 pub struct QDiscHandle(Handle);
 
 impl QDiscHandle {
@@ -57,6 +58,7 @@ impl QDiscHandle {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficClassHandle {
     handle: Handle,
     ifindex: i32,
@@ -74,6 +76,7 @@ impl TrafficClassHandle {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficFilterHandle {
     handle: Handle,
     ifindex: i32,
@@ -118,6 +121,7 @@ impl TrafficFilterHandle {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TrafficChainHandle {
     handle: Handle,
     ifindex: i32,


### PR DESCRIPTION
Sometimes we need to change both IPv4 and v6 at the same time, so building with common options first, and then cloning and applying twice will make code cleaner.