### PR TITLE
route: allow IPv6 gateway in IPv4 route

### DIFF
--- a/examples/add_route.rs
+++ b/examples/add_route.rs
@@ -42,7 +42,7 @@ async fn add_route(
 ) -> Result<(), Error> {
     let route = RouteMessageBuilder::<Ipv4Addr>::new()
         .destination_prefix(dest.ip(), dest.prefix())
-        .gateway(gateway.ip())
+        .gateway(gateway.ip().into())
         .table_id(TEST_TABLE_ID)
         .build();
     handle.route().add(route).execute().await?;


### PR DESCRIPTION
Linux supports it by using RTA_VIA instead of RTA_GATEWAY. Since it essentially acts as gateway, we extend the current API to allow it.