### PR TITLE
New release 0.15.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,23 @@
 # Changelog
+## [0.15.0] - 2025-03-10
+### Breaking changes
+ - Deprecated `LinkAddRequest::xfrmtun()` in the favor of
+   `LinkAddRequest::xfrmtun_link`. (de62338)
+ - Changed `RouteGetRequest::new()` to use `RouteMessageBuilder`. (9be24c6)
+ - Changed `LinkAddRequest()` and `LinkSetRequest` to use
+   `LinkMessageBuilder`. (230a729)
+
+### New features
+ - Support specifying link when crating xfrm interface. (de62338)
+ - Support creating VRF link. (6863102)
+ - Introducing `RouteAddRequest` for building netlink message for adding
+   routes. (b5e0cb6, 24bf04f)
+ - Reexport `netlink-*` packages. (a4d2611)
+ - impl Debug, Clone for all requests and handles. (515471f)
+
+### Bug fixes
+ - N/A
+
 ## [0.14.1] - 2024-02-01
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
 - Deprecated `LinkAddRequest::xfrmtun()` in the favor of
   `LinkAddRequest::xfrmtun_link`. (de62338)
 - Changed `RouteGetRequest::new()` to use `RouteMessageBuilder`. (9be24c6)
 - Changed `LinkAddRequest()` and `LinkSetRequest` to use
   `LinkMessageBuilder`. (230a729)

=== New features
 - Support specifying link when crating xfrm interface. (de62338)
 - Support creating VRF link. (6863102)
 - Introducing `RouteAddRequest` for building netlink message for adding
   routes. (b5e0cb6, 24bf04f)
 - Reexport `netlink-*` packages. (a4d2611)
 - impl Debug, Clone for all requests and handles. (515471f)

=== Bug fixes
 - N/A