### PR TITLE
New release 0.16.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.16.0] - 2025-03-10
+### Breaking changes
+ - N/A
+
+### New features
+ - Add support of tc filter del command. (51cfceb)
+
+### Bug fixes
+ - Fix error on decoding empty `IFLA_VFINFO_LIST`. (581b4ac)
+
 ## [0.15.0] - 2025-03-10
 ### Breaking changes
  - Deprecated `LinkAddRequest::xfrmtun()` in the favor of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
 netlink-packet-utils = { version = "0.5" }
-netlink-packet-route = { version = "0.21" }
+netlink-packet-route = { version = "0.22" }
 netlink-packet-core = { version = "0.7" }
 netlink-proto = { default-features = false, version = "0.11" }
 nix = { version = "0.29.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2018"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
- N/A

=== New features
- Add support of tc filter del command. (51cfceb)

=== Bug fixes
- Fix error on decoding empty `IFLA_VFINFO_LIST`. (581b4ac)