### PR TITLE
route: Implement support for the ONLINK flag

### DIFF
--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -7,8 +7,8 @@ use std::{
 
 use netlink_packet_route::{
     route::{
-        RouteAddress, RouteAttribute, RouteHeader, RouteMessage, RouteProtocol,
-        RouteScope, RouteType,
+        RouteAddress, RouteAttribute, RouteFlags, RouteHeader, RouteMessage,
+        RouteProtocol, RouteScope, RouteType,
     },
     AddressFamily,
 };
@@ -93,6 +93,15 @@ impl<T> RouteMessageBuilder<T> {
     /// Default is unicast route kind.
     pub fn kind(mut self, kind: RouteType) -> Self {
         self.message.header.kind = kind;
+        self
+    }
+
+    /// Marks the next hop as directly reachable (on-link).
+    ///
+    /// Indicates that the next hop is reachable without passing through a
+    /// connected subnet.
+    pub fn onlink(mut self) -> Self {
+        self.message.header.flags.insert(RouteFlags::Onlink);
         self
     }
 


### PR DESCRIPTION
This is an alternative to #41, which seems to be stale. In this PR, I didn't expose all the route flags since most of them don't really make sense when creating a route. I think it's better to add small builder methods for the flags that do make sense.