### PR TITLE
Allow `TrafficGetFilterRequest` to get ingress or egress filters

### DIFF
--- a/src/traffic_control/get.rs
+++ b/src/traffic_control/get.rs
@@ -136,6 +136,24 @@ impl TrafficFilterGetRequest {
         self.message.header.parent = TcHandle::ROOT;
         self
     }
+
+    /// Set parent to ingress.
+    pub fn ingress(mut self) -> Self {
+        self.message.header.parent = TcHandle {
+            major: 0xffff,
+            minor: TcHandle::MIN_INGRESS,
+        };
+        self
+    }
+
+    /// Set parent to egress.
+    pub fn egress(mut self) -> Self {
+        self.message.header.parent = TcHandle {
+            major: 0xffff,
+            minor: TcHandle::MIN_EGRESS,
+        };
+        self
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I'm using this library to make sure there aren't any other bpf programs bound to a qdisc before deleting it. Bpf programs show up as ingress and egress traffic control filters which it seems this library isn't currently able to query.

These changes are based on [what `bpftool` does](https://github.com/libbpf/bpftool/blob/c03ee3921594fd40b71cbfc17de66d414cd4d5bd/src/net.c#L554-L574), copying the already existing `root` (just above these changes) but setting `ingress` and `egress`. And I'm just noticing that it ended up being an exact copy of functions from [`TrafficFilterNewRequest`](https://github.com/rust-netlink/rtnetlink/blob/2423645faed3fdad55eb8ea9fe7ea8b0649e6b26/src/traffic_control/add_filter.rs#L85-L101)

---

These options are the equivalent of:

    tc filter show dev DEV ingress

and

    tc filter show dev DEV egress