### PR TITLE
Upgrade `netlink-packet-utils` to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
-netlink-packet-utils = { version = "0.5" }
+netlink-packet-utils = { version = "0.6" }
 netlink-packet-route = { version = "0.22" }
 netlink-packet-core = { version = "0.7" }
 netlink-proto = { default-features = false, version = "0.11" }


### PR DESCRIPTION
The latest version has a fix for RUSTSEC-2024-0436.