### PR TITLE
Create AddressMessageBuilder

### DIFF
--- a/examples/del_address.rs
+++ b/examples/del_address.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+use std::{
+    env,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+};
+
+use ipnetwork::IpNetwork;
+use rtnetlink::{new_connection, AddressMessageBuilder, Error, Handle};
+
+#[tokio::main]
+async fn main() -> Result<(), ()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        usage();
+        return Ok(());
+    }
+
+    let link_name = &args[1];
+    let ip: IpNetwork = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("invalid address");
+        std::process::exit(1);
+    });
+
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    if let Err(e) = del_address(link_name, ip, handle.clone()).await {
+        eprintln!("{e}");
+    }
+    Ok(())
+}
+
+async fn del_address(
+    link_name: &str,
+    ip: IpNetwork,
+    handle: Handle,
+) -> Result<(), Error> {
+    let mut links = handle
+        .link()
+        .get()
+        .match_name(link_name.to_string())
+        .execute();
+    if let Some(link) = links.try_next().await? {
+        let index = link.header.index;
+        let address = ip.ip();
+        let prefix_len = ip.prefix();
+        let message = match address {
+            IpAddr::V4(address) => AddressMessageBuilder::<Ipv4Addr>::new()
+                .index(index)
+                .address(address, prefix_len)
+                .build(),
+            IpAddr::V6(address) => AddressMessageBuilder::<Ipv6Addr>::new()
+                .index(index)
+                .address(address, prefix_len)
+                .build(),
+        };
+        handle.address().del(message).execute().await?
+    }
+    Ok(())
+}
+
+fn usage() {
+    eprintln!(
+        "usage:
+    cargo run --example del_address -- <link_name> <ip_address>
+
+Note that you need to run this program as root. Instead of running cargo as root,
+build the example normally:
+
+    cd rtnetlink ; cargo build --example del_address
+
+Then find the binary in the target directory:
+
+    cd ../target/debug/example ; sudo ./del_address <link_name> <ip_address>"
+    );
+}

--- a/src/addr/builder.rs
+++ b/src/addr/builder.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+
+use std::{
+    marker::PhantomData,
+    net::{Ipv4Addr, Ipv6Addr},
+};
+
+use netlink_packet_route::{
+    address::{AddressAttribute, AddressMessage},
+    AddressFamily,
+};
+
+#[derive(Debug)]
+/// Helper struct for building [AddressMessage].
+pub struct AddressMessageBuilder<T> {
+    message: AddressMessage,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> AddressMessageBuilder<T> {
+    /// Create a new [AddressMessageBuilder] without specifying the address family.
+    fn new_no_address_family() -> Self {
+        AddressMessageBuilder {
+            message: AddressMessage::default(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Sets the interface index.
+    pub fn index(mut self, index: u32) -> Self {
+        self.message.header.index = index;
+        self
+    }
+
+    /// Builds [AddressMessage].
+    pub fn build(self) -> AddressMessage {
+        self.message
+    }
+}
+
+impl AddressMessageBuilder<Ipv4Addr> {
+    /// Create a new [AddressMessageBuilder] for IPv4 addresses.
+    pub fn new() -> Self {
+        let mut builder = Self::new_no_address_family();
+        builder.message.header.family = AddressFamily::Inet;
+        builder
+    }
+
+    /// Sets the address and prefix length.
+    pub fn address(mut self, address: Ipv4Addr, prefix_len: u8) -> Self {
+        self.message.header.prefix_len = prefix_len;
+
+        if !address.is_multicast() {
+            self.message
+                .attributes
+                .push(AddressAttribute::Address(address.into()));
+
+            // The IFA_LOCAL address can be set to the same value as IFA_ADDRESS.
+            self.message
+                .attributes
+                .push(AddressAttribute::Local(address.into()));
+
+            // Set the IFA_BROADCAST address as well.
+            if prefix_len == 32 {
+                self.message
+                    .attributes
+                    .push(AddressAttribute::Broadcast(address));
+            } else {
+                let ip_addr = u32::from(address);
+                let brd = Ipv4Addr::from(
+                    (0xffff_ffff_u32) >> u32::from(prefix_len) | ip_addr,
+                );
+                self.message
+                    .attributes
+                    .push(AddressAttribute::Broadcast(brd));
+            };
+        }
+
+        self
+    }
+}
+
+impl AddressMessageBuilder<Ipv6Addr> {
+    /// Create a new [AddressMessageBuilder] for IPv6 addresses.
+    pub fn new() -> Self {
+        let mut builder = Self::new_no_address_family();
+        builder.message.header.family = AddressFamily::Inet6;
+        builder
+    }
+
+    /// Sets the address and prefix length.
+    pub fn address(mut self, address: Ipv6Addr, prefix_len: u8) -> Self {
+        self.message.header.prefix_len = prefix_len;
+
+        if address.is_multicast() {
+            self.message
+                .attributes
+                .push(AddressAttribute::Multicast(address));
+        } else {
+            self.message
+                .attributes
+                .push(AddressAttribute::Address(address.into()));
+
+            // The IFA_LOCAL address can be set to the same value as IFA_ADDRESS.
+            self.message
+                .attributes
+                .push(AddressAttribute::Local(address.into()));
+        }
+
+        self
+    }
+}

--- a/src/addr/mod.rs
+++ b/src/addr/mod.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 mod add;
+mod builder;
 mod del;
 mod get;
 mod handle;
 
 pub use self::add::AddressAddRequest;
+pub use self::builder::AddressMessageBuilder;
 pub use self::del::AddressDelRequest;
 pub use self::get::AddressGetRequest;
 pub use self::handle::AddressHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod traffic_control;
 
 pub use crate::addr::{
     AddressAddRequest, AddressDelRequest, AddressGetRequest, AddressHandle,
+    AddressMessageBuilder,
 };
 pub use crate::connection::from_socket;
 #[cfg(feature = "tokio_socket")]


### PR DESCRIPTION
Resolves #105.

This change creates a builder that builds address messages for AddressAddRequest and AddressDelRequest. This simplifies the way to delete an IP address.

Also creates an example for address deletion.

This change does not introduce any crate API change.