### PR TITLE
example: Fix kernel route filter

### DIFF
--- a/examples/get_route_kernel_filter.rs
+++ b/examples/get_route_kernel_filter.rs
@@ -26,9 +26,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("dumping routes for IPv4 in table 254");
     let route = RouteMessageBuilder::<Ipv4Addr>::new()
         .table_id(254)
-        .protocol(RouteProtocol::Boot)
+        .protocol(RouteProtocol::Unspec)
         .scope(RouteScope::Universe)
-        .kind(RouteType::Unicast)
+        .kind(RouteType::Unspec)
         .build();
     let mut routes = handle.route().get(route).execute();
     while let Some(route) = routes.try_next().await? {


### PR DESCRIPTION
Current example code of  `get_route_kernel_filter` is confusing people
because it placed too strict filter rules leading empty output.

Changed the filter to:

```rust
.table_id(254)
.protocol(RouteProtocol::Unspec)
.scope(RouteScope::Universe)
.kind(RouteType::Unspec)
```