### PR TITLE
New release 0.18.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.18.1] - 2025-09-09
+### Breaking changes
+ - N/A
+
+### New features
+ - route: Support defining ECMP weight. (7fcba62)
+ - route: Support defining ECMP flags. (18c4331)
+ - route: allow IPv6 gateway in IPv4 route. (e1784a3)
+
+### Bug fixes
+ - N/A
+
 ## [0.18.0] - 2025-08-27
 ### Breaking changes
  - Please check `netlink-packet-route` 0.25.0 breaking changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - route: Support defining ECMP weight. (7fcba62)
 - route: Support defining ECMP flags. (18c4331)
 - route: allow IPv6 gateway in IPv4 route. (e1784a3)

=== Bug fixes
 - N/A