### PR TITLE
Add function on RouteMessageBuilder for setting route MTU

### DIFF
--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -12,8 +12,8 @@ use netlink_packet_route::route::{
 use netlink_packet_route::{
     route::{
         RouteAddress, RouteAttribute, RouteFlags, RouteHeader, RouteMessage,
-        RouteNextHop, RouteNextHopFlags, RouteProtocol, RouteScope, RouteType,
-        RouteVia,
+        RouteMetric, RouteNextHop, RouteNextHopFlags, RouteProtocol,
+        RouteScope, RouteType, RouteVia,
     },
     AddressFamily,
 };
@@ -100,6 +100,14 @@ impl<T> RouteMessageBuilder<T> {
         self.message
             .attributes
             .push(RouteAttribute::Priority(priority));
+        self
+    }
+
+    /// Sets the route mtu (metric)
+    pub fn mtu(mut self, mtu: u32) -> Self {
+        self.message
+            .attributes
+            .push(RouteAttribute::Metrics(vec![RouteMetric::Mtu(mtu)]));
         self
     }
 


### PR DESCRIPTION
Title. Found myself doing the following thing in my code:
```rust
let message_builder = RouteMessageBuilder::<Ipv4Addr>::new();
// Assemble the RouteMessage
let mut msg: RouteMessage = message_builder.build();
// HACK: Set route MTU on the assembled RouteMessage
// TODO: Submit PR upstream for doing this on the builder instead.
let mtu = RouteMetric::Mtu(1280);
msg.attributes.push(RouteAttribute::Metrics(vec![mtu]));
```

With this patch, I would not need to create a mutable `RouteMessage` :)

```rust
let msg = RouteMessageBuilder::<Ipv4Addr>::new()
    .mtu(1280)
    .build();
```