### PR TITLE
Add function on RouteMessageBuilder for setting route mark

### DIFF
--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -115,6 +115,13 @@ impl<T> RouteMessageBuilder<T> {
         self
     }
 
+    #[cfg(not(target_os = "android"))]
+    /// Sets mark value on route.
+    pub fn mark(mut self, mark: u32) -> Self {
+        self.message.attributes.push(RouteAttribute::Mark(mark));
+        self
+    }
+
     /// Sets the route protocol.
     ///
     /// Default is static route protocol.


### PR DESCRIPTION
Like #126, I found myself wanting this function. Instead I had to assemble the builder into a mutable `RouteMessage` in order to push the route attribute manually :)