### PR TITLE
Bump `nix` to `0.30.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ netlink-sys = { version = "0.8" }
 netlink-packet-route = { version = "0.25" }
 netlink-packet-core = { version = "0.8" }
 netlink-proto = { default-features = false, version = "0.12.0" }
-nix = { version = "0.29.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }
+nix = { version = "0.30.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }
 tokio = { version = "1.0.1", features = ["rt"], optional = true}
 async-global-executor = { version = "2.0.2", optional = true }
 

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use std::{os::fd::BorrowedFd, path::Path, process::exit};
+use std::{path::Path, process::exit};
 
 use nix::{
     fcntl::OFlag,
@@ -331,10 +331,7 @@ impl NetworkNamespace {
         }
 
         setns_flags.insert(CloneFlags::CLONE_NEWNET);
-        if let Err(e) = nix::sched::setns(
-            unsafe { BorrowedFd::borrow_raw(fd) },
-            setns_flags,
-        ) {
+        if let Err(e) = nix::sched::setns(fd, setns_flags) {
             log::error!("setns error: {}", e);
             let err_msg = format!("setns error: {e}");
             let _ = nix::unistd::unlink(ns_path);


### PR DESCRIPTION
This PR bumps the minimum version of `nix` to `0.30.0`. One immediate benefit of this is that we can get rid of one use of `unsafe` while calling `setns` :)