### PR TITLE
Swap `futures` dependency for `futures-util` and `futures-channel`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ tokio_socket = ["netlink-proto/tokio_socket", "tokio"]
 smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 
 [dependencies]
-futures = "0.3.11"
+futures-util = "0.3.11"
+futures-channel = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }

--- a/examples/add_address.rs
+++ b/examples/add_address.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use ipnetwork::IpNetwork;
 use rtnetlink::{new_connection, Error, Handle};
 

--- a/examples/add_neighbour.rs
+++ b/examples/add_neighbour.rs
@@ -2,7 +2,7 @@
 
 use std::{convert::TryFrom, env, net::IpAddr};
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]

--- a/examples/add_route_pref_src.rs
+++ b/examples/add_route_pref_src.rs
@@ -2,7 +2,7 @@
 
 use std::{env, net::Ipv4Addr};
 
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 use ipnetwork::Ipv4Network;
 use rtnetlink::{new_connection, Error, Handle, RouteMessageBuilder};
 

--- a/examples/create_macvlan.rs
+++ b/examples/create_macvlan.rs
@@ -2,7 +2,7 @@
 
 use std::{env, str::FromStr};
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use macaddr::MacAddr;
 use rtnetlink::{
     new_connection, packet_route::link::MacVlanMode, Error, Handle, LinkMacVlan,

--- a/examples/create_macvtap.rs
+++ b/examples/create_macvtap.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{
     new_connection, packet_route::link::MacVtapMode, Error, Handle, LinkMacVtap,
 };

--- a/examples/create_vxlan.rs
+++ b/examples/create_vxlan.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, LinkVxlan};
 
 #[tokio::main]

--- a/examples/create_xfrm.rs
+++ b/examples/create_xfrm.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, LinkXfrm};
 
 #[tokio::main]

--- a/examples/del_address.rs
+++ b/examples/del_address.rs
@@ -5,7 +5,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use ipnetwork::IpNetwork;
 use rtnetlink::{new_connection, AddressMessageBuilder, Error, Handle};
 

--- a/examples/del_link.rs
+++ b/examples/del_link.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]

--- a/examples/flush_addresses.rs
+++ b/examples/flush_addresses.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]

--- a/examples/get_address.rs
+++ b/examples/get_address.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]

--- a/examples/get_bond_port_settings.rs
+++ b/examples/get_bond_port_settings.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{
     new_connection, packet_route::link::LinkAttribute, Error, Handle,
 };

--- a/examples/get_links.rs
+++ b/examples/get_links.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use netlink_packet_route::{
     link::{LinkAttribute, LinkExtentMask},
     AddressFamily,

--- a/examples/get_links_async.rs
+++ b/examples/get_links_async.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use netlink_packet_route::{
     link::{LinkAttribute, LinkExtentMask},
     AddressFamily,

--- a/examples/get_links_thread_builder.rs
+++ b/examples/get_links_thread_builder.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use netlink_packet_route::{
     link::{LinkAttribute, LinkExtentMask},
     AddressFamily,

--- a/examples/get_neighbours.rs
+++ b/examples/get_neighbours.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 
 #[tokio::main]

--- a/examples/get_route.rs
+++ b/examples/get_route.rs
@@ -2,7 +2,7 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{
     new_connection, Error, Handle, IpVersion, RouteMessageBuilder,
 };

--- a/examples/get_route_kernel_filter.rs
+++ b/examples/get_route_kernel_filter.rs
@@ -2,7 +2,7 @@
 
 use std::net::Ipv4Addr;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{
     new_connection,
     packet_route::route::{RouteProtocol, RouteScope, RouteType},

--- a/examples/get_rule.rs
+++ b/examples/get_rule.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, IpVersion};
 
 #[tokio::main]

--- a/examples/ip_monitor.rs
+++ b/examples/ip_monitor.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use rtnetlink::{new_multicast_connection, MulticastGroup};
 
 #[tokio::main]

--- a/examples/listen.rs
+++ b/examples/listen.rs
@@ -3,7 +3,7 @@
 //! This example opens a netlink socket, registers for IPv4 and IPv6 routing
 //! changes, listens for said changes and prints the received messages.
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_sys::{AsyncSocket, SocketAddr};
 use rtnetlink::{
     constants::{

--- a/examples/property_altname.rs
+++ b/examples/property_altname.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use netlink_packet_route::link::{LinkAttribute, LinkMessage, Prop};
 use rtnetlink::{new_connection, Error, Handle};
 

--- a/examples/set_bond_port.rs
+++ b/examples/set_bond_port.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{
     new_connection,
     packet_route::link::{BondMode, LinkAttribute},

--- a/examples/set_link_down.rs
+++ b/examples/set_link_down.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use rtnetlink::{new_connection, Error, Handle, LinkUnspec};
 
 #[tokio::main]

--- a/src/addr/add.rs
+++ b/src/addr/add.rs
@@ -2,7 +2,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE,
     NLM_F_REQUEST,

--- a/src/addr/del.rs
+++ b/src/addr/del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{address::AddressMessage, RouteNetlinkMessage};
 

--- a/src/addr/get.rs
+++ b/src/addr/get.rs
@@ -2,7 +2,7 @@
 
 use std::net::IpAddr;
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt, TryStreamExt},
     FutureExt,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use futures::channel::mpsc::UnboundedReceiver;
+use futures_channel::mpsc::UnboundedReceiver;
 use netlink_packet_core::NetlinkMessage;
 use netlink_packet_route::RouteNetlinkMessage;
 use netlink_proto::Connection;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::Stream;
+use futures_util::stream::Stream;
 use netlink_packet_core::NetlinkMessage;
 use netlink_packet_route::RouteNetlinkMessage;
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};

--- a/src/link/add.rs
+++ b/src/link/add.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE,
     NLM_F_REQUEST,

--- a/src/link/del.rs
+++ b/src/link/del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{link::LinkMessage, RouteNetlinkMessage};
 

--- a/src/link/get.rs
+++ b/src/link/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt},
     FutureExt,

--- a/src/link/property_add.rs
+++ b/src/link/property_add.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_APPEND, NLM_F_CREATE,
     NLM_F_EXCL, NLM_F_REQUEST,

--- a/src/link/property_del.rs
+++ b/src/link/property_del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_REQUEST,
 };

--- a/src/link/set.rs
+++ b/src/link/set.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST,
 };

--- a/src/link/test.rs
+++ b/src/link/test.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use tokio::runtime::Runtime;
 
 use crate::{

--- a/src/neighbour/add.rs
+++ b/src/neighbour/add.rs
@@ -2,7 +2,7 @@
 
 use std::net::IpAddr;
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL,
     NLM_F_REPLACE, NLM_F_REQUEST,

--- a/src/neighbour/del.rs
+++ b/src/neighbour/del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_REQUEST,
 };

--- a/src/neighbour/get.rs
+++ b/src/neighbour/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt},
     FutureExt,

--- a/src/route/add.rs
+++ b/src/route/add.rs
@@ -2,7 +2,7 @@
 
 use std::{marker::PhantomData, net::IpAddr};
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE,
     NLM_F_REQUEST,

--- a/src/route/del.rs
+++ b/src/route/del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NetlinkPayload, NLM_F_ACK, NLM_F_REQUEST,
 };

--- a/src/route/get.rs
+++ b/src/route/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt},
     FutureExt,

--- a/src/rule/add.rs
+++ b/src/rule/add.rs
@@ -5,7 +5,7 @@ use std::{
     net::{Ipv4Addr, Ipv6Addr},
 };
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{
     NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REPLACE,
     NLM_F_REQUEST,

--- a/src/rule/del.rs
+++ b/src/rule/del.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{rule::RuleMessage, RouteNetlinkMessage};
 

--- a/src/rule/get.rs
+++ b/src/rule/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt},
     FutureExt,

--- a/src/traffic_control/add_filter.rs
+++ b/src/traffic_control/add_filter.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 
 use crate::{
     packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST},
@@ -179,7 +179,7 @@ impl TrafficFilterNewRequest {
 mod test {
     use std::{fs::File, os::fd::AsFd, path::Path};
 
-    use futures::stream::TryStreamExt;
+    use futures_util::stream::TryStreamExt;
     use nix::sched::{setns, CloneFlags};
     use tokio::runtime::Runtime;
 

--- a/src/traffic_control/add_qdisc.rs
+++ b/src/traffic_control/add_qdisc.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 
 use crate::{
     packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST},
@@ -80,7 +80,7 @@ impl QDiscNewRequest {
 mod test {
     use std::{fs::File, os::fd::AsFd, path::Path};
 
-    use futures::stream::TryStreamExt;
+    use futures_util::stream::TryStreamExt;
     use nix::sched::{setns, CloneFlags};
     use tokio::runtime::Runtime;
 

--- a/src/traffic_control/del_filter.rs
+++ b/src/traffic_control/del_filter.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{
     tc::{TcHandle, TcMessage},

--- a/src/traffic_control/del_qdisc.rs
+++ b/src/traffic_control/del_qdisc.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::StreamExt;
+use futures_util::stream::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_route::{tc::TcMessage, RouteNetlinkMessage};
 

--- a/src/traffic_control/get.rs
+++ b/src/traffic_control/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{
+use futures_util::{
     future::{self, Either},
     stream::{Stream, StreamExt},
     FutureExt,

--- a/src/traffic_control/test.rs
+++ b/src/traffic_control/test.rs
@@ -2,7 +2,7 @@
 
 use std::process::Command;
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 use netlink_packet_core::ErrorMessage;
 use netlink_packet_route::{
     tc::{TcAttribute, TcMessage},


### PR DESCRIPTION
The entirety of `futures` is not used, so `futures-util` + `futures-channel` might be a better choice

Ref https://github.com/rust-netlink/rtnetlink/issues/84

This won't have any effect on binary sizes until https://github.com/rust-netlink/netlink-sys/pull/30 and https://github.com/rust-netlink/netlink-proto/pull/35 is merged and the `netlink-sys` + `netlink-proto` dependencies are bumped