### PR TITLE
vlan: Add wrapper for setting VLAN protocol and flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-channel = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
-netlink-packet-route = { version = "0.25" }
+netlink-packet-route = { version = "0.26" }
 netlink-packet-core = { version = "0.8" }
 netlink-proto = { default-features = false, version = "0.12.0" }
 nix = { version = "0.30.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }

--- a/src/link/vlan.rs
+++ b/src/link/vlan.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-    packet_route::link::{InfoData, InfoKind, InfoVlan, VlanQosMapping},
+    packet_route::link::{
+        InfoData, InfoKind, InfoVlan, VlanFlags, VlanProtocol, VlanQosMapping,
+    },
     LinkMessageBuilder,
 };
 
@@ -78,6 +80,16 @@ impl LinkMessageBuilder<LinkVlan> {
     /// VLAN ID
     pub fn id(self, vlan_id: u16) -> Self {
         self.append_info_data(InfoVlan::Id(vlan_id))
+    }
+
+    /// VLAN protocol
+    pub fn protocol(self, protocol: VlanProtocol) -> Self {
+        self.append_info_data(InfoVlan::Protocol(protocol))
+    }
+
+    /// VLAN flags
+    pub fn flags(self, flags: VlanFlags, mask: VlanFlags) -> Self {
+        self.append_info_data(InfoVlan::Flags((flags, mask)))
     }
 
     /// ingress QoS and egress QoS


### PR DESCRIPTION
Added these methods for `LinkMessageBuilder<LinkVlan>`:
 * `LinkMessageBuilder<LinkVlan>::protocol()`
 * `LinkMessageBuilder<LinkVlan>::flags()`