### PR TITLE
link: Add support for `netkit` devices

### DIFF
--- a/examples/create_netkit.rs
+++ b/examples/create_netkit.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+use rtnetlink::{new_connection, packet_route::link::NetkitMode, LinkNetkit};
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    // Create a netkit pair in L3 mode
+    handle
+        .link()
+        .add(LinkNetkit::new("netkit0", "netkit0-peer", NetkitMode::L3).build())
+        .execute()
+        .await
+        .map_err(|e| format!("{e}"))
+}

--- a/examples/create_netkit_advanced.rs
+++ b/examples/create_netkit_advanced.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+use rtnetlink::{
+    new_connection,
+    packet_route::link::{NetkitMode, NetkitPolicy, NetkitScrub},
+    LinkNetkit,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    // Create a fully-configured netkit pair in L3 mode
+    // This example shows all available configuration options
+    handle
+        .link()
+        .add(
+            LinkNetkit::new("netkit0", "netkit0-peer", NetkitMode::L3)
+                .policy(NetkitPolicy::Pass) // Forward packets normally on primary
+                .peer_policy(NetkitPolicy::Pass) // Forward packets normally on peer
+                .scrub(NetkitScrub::Default) // Apply default packet scrubbing
+                .peer_scrub(NetkitScrub::Default) // Apply scrubbing on peer
+                .headroom(256) // Reserve 256 bytes of headroom
+                .tailroom(128) // Reserve 128 bytes of tailroom
+                .up() // Bring the interface up
+                .build(),
+        )
+        .execute()
+        .await
+        .map_err(|e| format!("{e}"))?;
+
+    println!("Created netkit pair: netkit0 <-> netkit0-peer");
+    println!("  Mode: L3 (IP mode)");
+    println!("  Policy: Pass (Forward)");
+    println!("  Scrub: Default");
+    println!("  Headroom: 256 bytes");
+    println!("  Tailroom: 128 bytes");
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,9 @@ pub use crate::{
     link::{
         LinkAddRequest, LinkBond, LinkBondPort, LinkBridge, LinkDelPropRequest,
         LinkDelRequest, LinkDummy, LinkGetRequest, LinkHandle, LinkMacSec,
-        LinkMacVlan, LinkMacVtap, LinkMessageBuilder, LinkSetRequest,
-        LinkUnspec, LinkVeth, LinkVlan, LinkVrf, LinkVxlan, LinkWireguard,
-        LinkXfrm, QosMapping,
+        LinkMacVlan, LinkMacVtap, LinkMessageBuilder, LinkNetkit,
+        LinkSetRequest, LinkUnspec, LinkVeth, LinkVlan, LinkVrf, LinkVxlan,
+        LinkWireguard, LinkXfrm, QosMapping,
     },
     multicast::MulticastGroup,
     neighbour::{

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -12,6 +12,7 @@ mod handle;
 mod mac_vlan;
 mod mac_vtap;
 mod macsec;
+mod netkit;
 mod property_add;
 mod property_del;
 mod set;
@@ -35,6 +36,7 @@ pub use self::{
     mac_vlan::LinkMacVlan,
     mac_vtap::LinkMacVtap,
     macsec::LinkMacSec,
+    netkit::LinkNetkit,
     property_add::LinkNewPropRequest,
     property_del::LinkDelPropRequest,
     set::LinkSetRequest,

--- a/src/link/netkit.rs
+++ b/src/link/netkit.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{
+    packet_route::link::{
+        InfoData, InfoKind, InfoNetkit, NetkitMode, NetkitPolicy, NetkitScrub,
+    },
+    LinkMessageBuilder, LinkUnspec,
+};
+
+#[derive(Debug)]
+/// Represent netkit virtual interface.
+/// Netkit devices are used for container networking and BPF programs.
+///
+/// Example code on creating a netkit pair:
+/// ```no_run
+/// use rtnetlink::{new_connection, LinkNetkit, packet_route::link::NetkitMode};
+/// #[tokio::main]
+/// async fn main() -> Result<(), String> {
+///     let (connection, handle, _) = new_connection().unwrap();
+///     tokio::spawn(connection);
+///
+///     handle
+///         .link()
+///         .add(LinkNetkit::new("netkit0", "netkit0-peer", NetkitMode::L3).build())
+///         .execute()
+///         .await
+///         .map_err(|e| format!("{e}"))
+/// }
+/// ```
+///
+/// Please check LinkMessageBuilder::<LinkNetkit> for more detail.
+pub struct LinkNetkit;
+
+impl LinkNetkit {
+    /// Equal to `LinkMessageBuilder::<LinkNetkit>::new(name, peer, mode)`
+    pub fn new(
+        name: &str,
+        peer: &str,
+        mode: NetkitMode,
+    ) -> LinkMessageBuilder<Self> {
+        LinkMessageBuilder::<LinkNetkit>::new(name, peer, mode)
+    }
+}
+
+impl LinkMessageBuilder<LinkNetkit> {
+    /// Create [LinkMessageBuilder] for netkit
+    pub fn new(name: &str, peer: &str, mode: NetkitMode) -> Self {
+        LinkMessageBuilder::<LinkNetkit>::new_with_info_kind(InfoKind::Netkit)
+            .name(name.to_string())
+            .mode(mode)
+            .peer(peer)
+    }
+
+    /// Set the peer interface name
+    pub fn peer(self, peer: &str) -> Self {
+        let peer_msg = LinkMessageBuilder::<LinkUnspec>::new()
+            .name(peer.to_string())
+            .build();
+
+        self.append_info_data(InfoNetkit::Peer(peer_msg))
+    }
+
+    /// Set the netkit mode (L2 or L3)
+    pub fn mode(self, mode: NetkitMode) -> Self {
+        self.append_info_data(InfoNetkit::Mode(mode))
+    }
+
+    /// Set the primary interface flag
+    pub fn primary(self, primary: bool) -> Self {
+        self.append_info_data(InfoNetkit::Primary(primary))
+    }
+
+    /// Set the policy for the primary interface
+    pub fn policy(self, policy: NetkitPolicy) -> Self {
+        self.append_info_data(InfoNetkit::Policy(policy))
+    }
+
+    /// Set the policy for the peer interface
+    pub fn peer_policy(self, policy: NetkitPolicy) -> Self {
+        self.append_info_data(InfoNetkit::PeerPolicy(policy))
+    }
+
+    /// Set the scrub settings for the primary interface
+    pub fn scrub(self, scrub: NetkitScrub) -> Self {
+        self.append_info_data(InfoNetkit::Scrub(scrub))
+    }
+
+    /// Set the scrub settings for the peer interface
+    pub fn peer_scrub(self, scrub: NetkitScrub) -> Self {
+        self.append_info_data(InfoNetkit::PeerScrub(scrub))
+    }
+
+    /// Set the desired headroom
+    pub fn headroom(self, headroom: u16) -> Self {
+        self.append_info_data(InfoNetkit::Headroom(headroom))
+    }
+
+    /// Set the desired tailroom
+    pub fn tailroom(self, tailroom: u16) -> Self {
+        self.append_info_data(InfoNetkit::Tailroom(tailroom))
+    }
+
+    /// Helper to append netkit-specific info data
+    fn append_info_data(mut self, info: InfoNetkit) -> Self {
+        if let InfoData::Netkit(ref mut infos) = self
+            .info_data
+            .get_or_insert_with(|| InfoData::Netkit(Vec::new()))
+        {
+            infos.push(info);
+        }
+        self
+    }
+}


### PR DESCRIPTION
Add support for `netkit` devices creation and configuration:
* L2 (Ethernet) and L3 (IP) operating modes
* Peer interface configuration
* Primary interface flag
* Traffic policies (Pass/Forward, Drop, Redirect)
* Packet scrubbing settings (None, Default)
* Peer-specific policy and scrub configuration
* Buffer headroom and tailroom settings

Example usage:
```rust
use rtnetlink::{new_connection, LinkNetkit};
use rtnetlink::packet_route::link::{NetkitMode, NetkitPolicy, NetkitScrub};

handle.link().add(
    LinkNetkit::new("netkit0", "netkit0-peer", NetkitMode::L3)
        .policy(NetkitPolicy::Pass)
        .scrub(NetkitScrub::Default)
        .headroom(256)
        .build()
).execute().await?;
```