### PR TITLE
link: Support specifying arbitrary LinkMessage for `RTM_DELLINK`

### DIFF
--- a/src/link/del.rs
+++ b/src/link/del.rs
@@ -18,6 +18,10 @@ impl LinkDelRequest {
         LinkDelRequest { handle, message }
     }
 
+    pub fn new_with_message(handle: Handle, message: LinkMessage) -> Self {
+        LinkDelRequest { handle, message }
+    }
+
     /// Execute the request
     pub async fn execute(self) -> Result<(), Error> {
         let LinkDelRequest {

--- a/src/link/handle.rs
+++ b/src/link/handle.rs
@@ -43,12 +43,19 @@ impl LinkHandle {
         LinkDelPropRequest::new(self.0.clone(), index)
     }
 
-    pub fn del(&mut self, index: u32) -> LinkDelRequest {
+    pub fn del(&self, index: u32) -> LinkDelRequest {
         LinkDelRequest::new(self.0.clone(), index)
     }
 
+    /// Delete specified information from interface.
+    /// For example: To delete bridge VLANs, it is required to include
+    /// LinkMessage of VLAN information to delete.
+    pub fn del_with_message(&self, message: LinkMessage) -> LinkDelRequest {
+        LinkDelRequest::new_with_message(self.0.clone(), message)
+    }
+
     /// Retrieve the list of links (equivalent to `ip link show`)
-    pub fn get(&mut self) -> LinkGetRequest {
+    pub fn get(&self) -> LinkGetRequest {
         LinkGetRequest::new(self.0.clone())
     }
 


### PR DESCRIPTION
In order to support deleting bridge VLAN information, this patch
introduced `LinkHandle::del_with_message()` allowing sending arbitrary
LinkMessage for the `RTM_DELLINK` call.

Example code updated with bridge VLAN deletion function.