### PR TITLE
Add vxcan

### DIFF
--- a/examples/create_vxcan.rs
+++ b/examples/create_vxcan.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+
+use futures_util::stream::TryStreamExt;
+use rtnetlink::{new_connection, Error, Handle, LinkUnspec, LinkVxcan};
+
+#[tokio::main]
+async fn main() -> Result<(), String> {
+    let (connection, handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let link_name = "vxcan0";
+    let peer_name = "vxcan0-peer";
+
+    handle
+        .link()
+        .add(LinkVxcan::new(link_name, peer_name).build())
+        .execute()
+        .await
+        .map_err(|e| format!("{e}"))?;
+
+    set_link_up(&handle, link_name)
+        .await
+        .map_err(|e| format!("{e}"))?;
+
+    set_link_up(&handle, peer_name)
+        .await
+        .map_err(|e| format!("{e}"))?;
+
+    Ok(())
+}
+
+async fn set_link_up(handle: &Handle, name: &str) -> Result<(), Error> {
+    let mut links = handle.link().get().match_name(name.to_string()).execute();
+    if let Some(link) = links.try_next().await? {
+        handle
+            .link()
+            .set(LinkUnspec::new_with_index(link.header.index).up().build())
+            .execute()
+            .await?
+    } else {
+        println!("no link {name} found");
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@ pub use crate::{
         LinkBridgeVlan, LinkDelPropRequest, LinkDelRequest, LinkDummy,
         LinkGetRequest, LinkHandle, LinkMacSec, LinkMacVlan, LinkMacVtap,
         LinkMessageBuilder, LinkNetkit, LinkSetRequest, LinkUnspec, LinkVeth,
-        LinkVlan, LinkVrf, LinkVxlan, LinkWireguard, LinkXfrm, QosMapping,
+        LinkVlan, LinkVrf, LinkVxcan, LinkVxlan, LinkWireguard, LinkXfrm,
+        QosMapping,
     },
     multicast::MulticastGroup,
     neighbour::{

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -22,6 +22,7 @@ mod set;
 mod veth;
 mod vlan;
 mod vrf;
+mod vxcan;
 mod vxlan;
 mod wireguard;
 mod xfrm;
@@ -47,6 +48,7 @@ pub use self::{
     veth::LinkVeth,
     vlan::{LinkVlan, QosMapping},
     vrf::LinkVrf,
+    vxcan::LinkVxcan,
     vxlan::LinkVxlan,
     wireguard::LinkWireguard,
     xfrm::LinkXfrm,

--- a/src/link/vxcan.rs
+++ b/src/link/vxcan.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{
+    packet_route::link::{InfoData, InfoKind, InfoVxcan},
+    LinkMessageBuilder, LinkUnspec,
+};
+
+/// Represent virtual can interface.
+/// Example code on creating a vxcan pair
+/// ```no_run
+/// use rtnetlink::{new_connection, LinkVxcan};
+/// #[tokio::main]
+/// async fn main() -> Result<(), String> {
+///     let (connection, handle, _) = new_connection().unwrap();
+///     tokio::spawn(connection);
+///
+///     handle
+///         .link()
+///         .add(LinkVxcan::new("vxcan0", "vxcan1").build())
+///         .execute()
+///         .await
+///         .map_err(|e| format!("{e}"))
+/// }
+/// ```
+///
+/// Please check LinkMessageBuilder::<LinkVxcan> for more detail.
+#[derive(Debug)]
+pub struct LinkVxcan;
+
+impl LinkVxcan {
+    /// Equal to `LinkMessageBuilder::<LinkVxcan>::new(name, peer)`
+    pub fn new(name: &str, peer: &str) -> LinkMessageBuilder<Self> {
+        LinkMessageBuilder::<LinkVxcan>::new(name, peer)
+    }
+}
+
+impl LinkMessageBuilder<LinkVxcan> {
+    /// Create [LinkMessageBuilder] for Vxcan
+    pub fn new(name: &str, peer: &str) -> Self {
+        LinkMessageBuilder::<LinkVxcan>::new_with_info_kind(InfoKind::Vxcan)
+            .name(name.to_string())
+            .peer(peer)
+    }
+
+    pub fn peer(mut self, peer: &str) -> Self {
+        let peer_msg = LinkMessageBuilder::<LinkUnspec>::new()
+            .name(peer.to_string())
+            .build();
+
+        self.info_data = Some(InfoData::Vxcan(InfoVxcan::Peer(peer_msg)));
+        self
+    }
+}


### PR DESCRIPTION
Add vxcan based on veth implementation.

Needs a release of netlink-packet-route 0.29.0 after https://github.com/rust-netlink/netlink-packet-route/pull/234 is merged.

So I did a separate commit to update the netlink-packet-route API to current main branch.