### PR TITLE
Use netlink-packet-route 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-channel = "0.3.11"
 log = "0.4.8"
 thiserror = "1"
 netlink-sys = { version = "0.8" }
-netlink-packet-route = { version = "0.29" }
+netlink-packet-route = { version = "0.30" }
 netlink-packet-core = { version = "0.8" }
 netlink-proto = { default-features = false, version = "0.12.0" }
 nix = { version = "0.30.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }

--- a/examples/add_neighbour.rs
+++ b/examples/add_neighbour.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), ()> {
         })
         .collect();
 
-    let link_local_address = <[u8; 6]>::try_from(link_local_parts).unwrap_or_else(|_| {
+    let link_layer_address = <[u8; 6]>::try_from(link_local_parts).unwrap_or_else(|_| {
         eprintln!("invalid mac address, please give it in the format of 56:78:90:ab:cd:ef");
         std::process::exit(1);
     });
@@ -38,7 +38,7 @@ async fn main() -> Result<(), ()> {
     tokio::spawn(connection);
 
     if let Err(e) =
-        add_neighbour(link_name, ip, link_local_address, handle.clone()).await
+        add_neighbour(link_name, ip, link_layer_address, handle.clone()).await
     {
         eprintln!("{e}");
     }
@@ -48,7 +48,7 @@ async fn main() -> Result<(), ()> {
 async fn add_neighbour(
     link_name: &str,
     ip: IpAddr,
-    link_local_address: [u8; 6],
+    link_layer_address: [u8; 6],
     handle: Handle,
 ) -> Result<(), Error> {
     let mut links = handle
@@ -60,7 +60,7 @@ async fn add_neighbour(
         handle
             .neighbours()
             .add(link.header.index, ip)
-            .link_local_address(&link_local_address)
+            .link_layer_address(&link_layer_address)
             .execute()
             .await?;
         println!("Done");

--- a/src/neighbour/add.rs
+++ b/src/neighbour/add.rs
@@ -62,7 +62,7 @@ impl NeighbourAddRequest {
 
         message
             .attributes
-            .push(NeighbourAttribute::LinkLocalAddress(lla.to_vec()));
+            .push(NeighbourAttribute::LinkLayerAddress(lla.to_vec()));
 
         NeighbourAddRequest {
             handle,
@@ -92,14 +92,25 @@ impl NeighbourAddRequest {
         self
     }
 
+    #[deprecated(
+        since = "0.21.0",
+        note = "please use `link_layer_address` instead"
+    )]
     /// Set a neighbor cache link layer address (see `NDA_LLADDR` for details).
-    pub fn link_local_address(mut self, addr: &[u8]) -> Self {
+    /// Deprecated. Please use [NeighbourAddRequest::link_layer_address()]
+    /// instead.
+    pub fn link_local_address(self, addr: &[u8]) -> Self {
+        self.link_layer_address(addr)
+    }
+
+    /// Set a neighbor cache link layer address (see `NDA_LLADDR` for details).
+    pub fn link_layer_address(mut self, addr: &[u8]) -> Self {
         let lla =
             self.message
                 .attributes
                 .iter_mut()
                 .find_map(|nla| match nla {
-                    NeighbourAttribute::LinkLocalAddress(lla) => Some(lla),
+                    NeighbourAttribute::LinkLayerAddress(lla) => Some(lla),
                     _ => None,
                 });
 
@@ -108,7 +119,7 @@ impl NeighbourAddRequest {
         } else {
             self.message
                 .attributes
-                .push(NeighbourAttribute::LinkLocalAddress(addr.to_vec()));
+                .push(NeighbourAttribute::LinkLayerAddress(addr.to_vec()));
         }
 
         self


### PR DESCRIPTION
The netlink-packet-route 0.30 fixed the typo on
`NeighbourAttribute::LinkLocalAddress`, it should be
`NeighbourAttribute::LinkLayerAddress` now.

Added `NeighbourAddRequest::link_layer_address()` and deprecated
`NeighbourAddRequest::link_local_address()`.