### PR TITLE
New release 0.21.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [0.21.0] - 2026-04-18
+### Breaking changes
+ - Use netlink-packet-route 0.30. (7bfbbf5)
+ - Deprecated `NeighbourAddRequest::link_layer_address()`, please use
+   `NeighbourAddRequest::link_local_address()`. (7bfbbf5)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - addr: only assign broadcast when subnet over /31. (7c16a2d)
+
 ## [0.20.0] - 2026-01-01
 ### Breaking changes
  - Please check breaking changes in netlink-packet-route 0.28.0 and 0.27.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
=== Breaking changes
 - Use netlink-packet-route 0.30. (7bfbbf5)
 - Deprecated `NeighbourAddRequest::link_layer_address()`, please use
   `NeighbourAddRequest::link_local_address()`. (7bfbbf5)

=== New features
 - N/A

=== Bug fixes
 - addr: only assign broadcast when subnet over /31. (7c16a2d)