### PR TITLE
Add function to get neighbours on bridge

### DIFF
--- a/examples/get_neighbours.rs
+++ b/examples/get_neighbours.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use futures_util::stream::TryStreamExt;
-use rtnetlink::{new_connection, Error, Handle, IpVersion};
+use netlink_packet_route::{neighbour::NeighbourFlags, AddressFamily};
+use rtnetlink::{new_connection, Error, Handle};
 
 #[tokio::main]
 async fn main() -> Result<(), ()> {
@@ -13,6 +14,11 @@ async fn main() -> Result<(), ()> {
         eprintln!("{e}");
     }
     println!();
+    println!("dumping neighbours on bridge interfaces");
+    if let Err(e) = dump_neighbours_bridge(handle.clone()).await {
+        eprintln!("{e}");
+    }
+    println!();
 
     Ok(())
 }
@@ -21,7 +27,20 @@ async fn dump_neighbours(handle: Handle) -> Result<(), Error> {
     let mut neighbours = handle
         .neighbours()
         .get()
-        .set_family(IpVersion::V4)
+        .set_address_family(AddressFamily::Inet)
+        .execute();
+    while let Some(route) = neighbours.try_next().await? {
+        println!("{route:?}");
+    }
+    Ok(())
+}
+
+async fn dump_neighbours_bridge(handle: Handle) -> Result<(), Error> {
+    let mut neighbours = handle
+        .neighbours()
+        .get()
+        .set_address_family(AddressFamily::Bridge)
+        .set_flags(NeighbourFlags::Own)
         .execute();
     while let Some(route) = neighbours.try_next().await? {
         println!("{route:?}");

--- a/src/neighbour/get.rs
+++ b/src/neighbour/get.rs
@@ -10,7 +10,7 @@ use netlink_packet_core::{
 };
 use netlink_packet_route::{
     neighbour::{NeighbourFlags, NeighbourMessage},
-    RouteNetlinkMessage,
+    AddressFamily, RouteNetlinkMessage,
 };
 
 use crate::{Error, Handle, IpVersion};
@@ -33,8 +33,22 @@ impl NeighbourGetRequest {
         self
     }
 
+    #[deprecated(
+        since = "0.22.0",
+        note = "please use `set_address_family` instead"
+    )]
     pub fn set_family(mut self, ip_version: IpVersion) -> Self {
         self.message.header.family = ip_version.family();
+        self
+    }
+
+    pub fn set_address_family(mut self, family: AddressFamily) -> Self {
+        self.message.header.family = family;
+        self
+    }
+
+    pub fn set_flags(mut self, flags: NeighbourFlags) -> Self {
+        self.message.header.flags = flags;
         self
     }
 

--- a/src/traffic_control/test.rs
+++ b/src/traffic_control/test.rs
@@ -238,9 +238,7 @@ async fn _get_chains(ifindex: i32) -> Vec<TcMessage> {
             Ok(None) => {
                 break;
             }
-            Err(NetlinkError(ErrorMessage {
-                code, header: _, ..
-            })) => {
+            Err(NetlinkError(ErrorMessage { code, .. })) => {
                 assert_eq!(code, std::num::NonZeroI32::new(-95));
                 eprintln!(
                     "The chain in traffic control is not supported, \


### PR DESCRIPTION
For a project of mine I needed the option to find the neighbours on bridge interfaces, specifically to find VXLAN remotes and came up with this solution for the problem and figured I'd contribute it back here.
Hope this helps and let me know if something needs to be changed