### PR TITLE
refactor: migrate to more permissive/accurate `String` parameter types

### DIFF
--- a/examples/add_route_pref_src.rs
+++ b/examples/add_route_pref_src.rs
@@ -38,10 +38,11 @@ async fn main() -> Result<(), ()> {
 
 async fn add_route(
     dest: &Ipv4Network,
-    iface: String,
+    iface: impl Into<String>,
     source: Ipv4Addr,
     handle: Handle,
 ) -> Result<(), Error> {
+    let iface = iface.into();
     let iface_idx = handle
         .link()
         .get()

--- a/examples/create_macvlan.rs
+++ b/examples/create_macvlan.rs
@@ -35,11 +35,11 @@ async fn main() -> Result<(), String> {
 
 async fn create_macvlan(
     handle: Handle,
-    link_name: String,
+    link_name: impl Into<String>,
     mac_address: Option<Vec<u8>>,
 ) -> Result<(), Error> {
-    let mut parent_links =
-        handle.link().get().match_name(link_name.clone()).execute();
+    let link_name = link_name.into();
+    let mut parent_links = handle.link().get().match_name(&link_name).execute();
     if let Some(parent) = parent_links.try_next().await? {
         let mut builder = LinkMacVlan::new(
             "my-macvlan",

--- a/examples/create_macvtap.rs
+++ b/examples/create_macvtap.rs
@@ -26,10 +26,10 @@ async fn main() -> Result<(), String> {
 
 async fn create_macvtap(
     handle: Handle,
-    link_name: String,
+    link_name: impl Into<String>,
 ) -> Result<(), Error> {
-    let mut parent_links =
-        handle.link().get().match_name(link_name.clone()).execute();
+    let link_name = link_name.into();
+    let mut parent_links = handle.link().get().match_name(&link_name).execute();
     if let Some(parent) = parent_links.try_next().await? {
         let message = LinkMacVtap::new(
             "test_macvtap",

--- a/examples/create_vlan.rs
+++ b/examples/create_vlan.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), String> {
 
     let mut mode = ParsingMode::None;
     for argument in args.drain(1..) {
-        fn match_argument(argument: String) -> Result<ParsingMode, String> {
+        fn match_argument(argument: &str) -> Result<ParsingMode, String> {
             match argument.to_lowercase().as_str() {
                 ARG_BASE => Ok(ParsingMode::Base),
                 ARG_NAME => Ok(ParsingMode::Name),
@@ -57,7 +57,7 @@ async fn main() -> Result<(), String> {
         }
 
         mode = match mode {
-            ParsingMode::None => match_argument(argument)?,
+            ParsingMode::None => match_argument(&argument)?,
             ParsingMode::Base => {
                 base_interface = u32::from_str(&argument).ok();
                 ParsingMode::None
@@ -75,14 +75,14 @@ async fn main() -> Result<(), String> {
                     ingress.push(mapping);
                     mode
                 }
-                Err(_) => match_argument(argument)?,
+                Err(_) => match_argument(&argument)?,
             },
             mode @ ParsingMode::Egress => match parse_mapping(&argument) {
                 Ok(mapping) => {
                     egress.push(mapping);
                     mode
                 }
-                Err(_) => match_argument(argument)?,
+                Err(_) => match_argument(&argument)?,
             },
         }
     }

--- a/examples/create_vxlan.rs
+++ b/examples/create_vxlan.rs
@@ -22,8 +22,12 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("{e}"))
 }
 
-async fn create_vxlan(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn create_vxlan(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if let Some(link) = links.try_next().await? {
         let message = LinkVxlan::new("vxlan0", 10)
             .dev(link.header.index)

--- a/examples/create_xfrm.rs
+++ b/examples/create_xfrm.rs
@@ -20,9 +20,12 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("{e}"))
 }
 
-async fn create_xfrm(handle: Handle, link_name: String) -> Result<(), Error> {
-    let mut parent_links =
-        handle.link().get().match_name(link_name.clone()).execute();
+async fn create_xfrm(
+    handle: Handle,
+    link_name: impl Into<String>,
+) -> Result<(), Error> {
+    let link_name = link_name.into();
+    let mut parent_links = handle.link().get().match_name(&link_name).execute();
     if let Some(parent) = parent_links.try_next().await? {
         let request = handle
             .link()

--- a/examples/del_link.rs
+++ b/examples/del_link.rs
@@ -23,8 +23,12 @@ async fn main() -> Result<(), ()> {
     Ok(())
 }
 
-async fn del_link(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn del_link(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if let Some(link) = links.try_next().await? {
         handle.link().del(link.header.index).execute().await
     } else {

--- a/examples/flush_addresses.rs
+++ b/examples/flush_addresses.rs
@@ -24,8 +24,12 @@ async fn main() -> Result<(), ()> {
     Ok(())
 }
 
-async fn flush_addresses(handle: Handle, link: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(link.clone()).execute();
+async fn flush_addresses(
+    handle: Handle,
+    link: impl Into<String>,
+) -> Result<(), Error> {
+    let link = link.into();
+    let mut links = handle.link().get().match_name(&link).execute();
     if let Some(link) = links.try_next().await? {
         // We should have received only one message
         assert!(links.try_next().await?.is_none());

--- a/examples/get_address.rs
+++ b/examples/get_address.rs
@@ -18,8 +18,12 @@ async fn main() -> Result<(), ()> {
     Ok(())
 }
 
-async fn dump_addresses(handle: Handle, link: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(link.clone()).execute();
+async fn dump_addresses(
+    handle: Handle,
+    link: impl Into<String>,
+) -> Result<(), Error> {
+    let link = link.into();
+    let mut links = handle.link().get().match_name(&link).execute();
     if let Some(link) = links.try_next().await? {
         let mut addresses = handle
             .address()

--- a/examples/get_bond_port_settings.rs
+++ b/examples/get_bond_port_settings.rs
@@ -31,12 +31,13 @@ async fn main() -> Result<(), ()> {
 
 async fn dump_bond_port_settings(
     handle: Handle,
-    linkname: String,
+    link_name: impl Into<String>,
 ) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(linkname.clone()).execute();
+    let link_name = link_name.into();
+    let mut links = handle.link().get().match_name(&link_name).execute();
     if let Some(_link) = links.try_next().await? {
         let mut link_messgage =
-            handle.link().get().match_name(linkname).execute();
+            handle.link().get().match_name(link_name).execute();
         while let Some(msg) = link_messgage.try_next().await? {
             for nla in msg.attributes {
                 if let LinkAttribute::LinkInfo(i) = &nla {
@@ -46,7 +47,7 @@ async fn dump_bond_port_settings(
         }
         Ok(())
     } else {
-        eprintln!("link {linkname} not found");
+        eprintln!("link {link_name} not found");
         Ok(())
     }
 }

--- a/examples/get_links.rs
+++ b/examples/get_links.rs
@@ -68,8 +68,12 @@ async fn get_link_by_index(handle: Handle, index: u32) -> Result<(), Error> {
     Ok(())
 }
 
-async fn get_link_by_name(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn get_link_by_name(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if (links.try_next().await?).is_some() {
         println!("found link {name}");
         // We should only have one link with that name

--- a/examples/get_links_async.rs
+++ b/examples/get_links_async.rs
@@ -68,8 +68,12 @@ async fn get_link_by_index(handle: Handle, index: u32) -> Result<(), Error> {
     Ok(())
 }
 
-async fn get_link_by_name(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn get_link_by_name(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if (links.try_next().await?).is_some() {
         println!("found link {name}");
         // We should only have one link with that name

--- a/examples/get_links_thread_builder.rs
+++ b/examples/get_links_thread_builder.rs
@@ -66,8 +66,12 @@ async fn get_link_by_index(handle: Handle, index: u32) -> Result<(), Error> {
     Ok(())
 }
 
-async fn get_link_by_name(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn get_link_by_name(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if (links.try_next().await?).is_some() {
         println!("found link {name}");
         // We should only have one link with that name

--- a/examples/set_link_down.rs
+++ b/examples/set_link_down.rs
@@ -22,8 +22,12 @@ async fn main() -> Result<(), String> {
         .map_err(|e| format!("{e}"))
 }
 
-async fn set_link_down(handle: Handle, name: String) -> Result<(), Error> {
-    let mut links = handle.link().get().match_name(name.clone()).execute();
+async fn set_link_down(
+    handle: Handle,
+    name: impl Into<String>,
+) -> Result<(), Error> {
+    let name = name.into();
+    let mut links = handle.link().get().match_name(&name).execute();
     if let Some(link) = links.try_next().await? {
         handle
             .link()

--- a/src/link/builder.rs
+++ b/src/link/builder.rs
@@ -149,8 +149,8 @@ impl<T> LinkMessageBuilder<T> {
         ret
     }
 
-    pub fn name(self, name: String) -> Self {
-        self.append_extra_attribute(LinkAttribute::IfName(name))
+    pub fn name(self, name: impl Into<String>) -> Self {
+        self.append_extra_attribute(LinkAttribute::IfName(name.into()))
     }
 
     /// Set the mtu of the link with the given index (equivalent to

--- a/src/link/get.rs
+++ b/src/link/get.rs
@@ -90,9 +90,11 @@ impl LinkGetRequest {
     ///
     /// This function requires support from your kernel (>= 2.6.33). If yours is
     /// older, consider filtering the resulting stream of links.
-    pub fn match_name(mut self, name: String) -> Self {
+    pub fn match_name(mut self, name: impl Into<String>) -> Self {
         self.dump = false;
-        self.message.attributes.push(LinkAttribute::IfName(name));
+        self.message
+            .attributes
+            .push(LinkAttribute::IfName(name.into()));
         self
     }
 }

--- a/src/link/test.rs
+++ b/src/link/test.rs
@@ -127,7 +127,7 @@ async fn _create_wg() -> Result<LinkHandle, Error> {
 
 async fn _get_iface(
     handle: &mut LinkHandle,
-    iface_name: String,
+    iface_name: impl Into<String>,
 ) -> Result<LinkMessage, Error> {
     let mut links = handle.get().match_name(iface_name).execute();
     let msg = links.try_next().await?;

--- a/src/ns.rs
+++ b/src/ns.rs
@@ -60,7 +60,7 @@ pub struct NetworkNamespace();
 impl NetworkNamespace {
     /// Add a new network namespace.
     /// This is equivalent to `ip netns add NS_NAME`.
-    pub async fn add(ns_name: String) -> Result<(), Error> {
+    pub async fn add(ns_name: impl AsRef<str>) -> Result<(), Error> {
         // Forking process to avoid moving caller into new namespace
         NetworkNamespace::prep_for_fork()?;
         log::trace!("Forking...");
@@ -69,7 +69,7 @@ impl NetworkNamespace {
                 NetworkNamespace::parent_process(child)
             }
             Ok(ForkResult::Child) => {
-                NetworkNamespace::child_process(ns_name);
+                NetworkNamespace::child_process(ns_name.as_ref());
             }
             Err(e) => {
                 let err_msg = format!("Fork failed: {e}");
@@ -80,15 +80,15 @@ impl NetworkNamespace {
 
     /// Remove a network namespace
     /// This is equivalent to `ip netns del NS_NAME`.
-    pub async fn del(ns_name: String) -> Result<(), Error> {
-        try_spawn_blocking(move || {
-            let mut netns_path = String::new();
-            netns_path.push_str(NETNS_PATH);
-            netns_path.push_str(&ns_name);
-            let ns_path = Path::new(&netns_path);
+    pub async fn del(ns_name: impl AsRef<str>) -> Result<(), Error> {
+        let netns_path = Path::new(NETNS_PATH).join(ns_name.as_ref());
 
-            if nix::mount::umount2(ns_path, nix::mount::MntFlags::MNT_DETACH)
-                .is_err()
+        try_spawn_blocking(move || {
+            if nix::mount::umount2(
+                &netns_path,
+                nix::mount::MntFlags::MNT_DETACH,
+            )
+            .is_err()
             {
                 let err_msg = String::from(
                     "Namespace unmount failed (are you running as root?)",
@@ -96,7 +96,7 @@ impl NetworkNamespace {
                 return Err(Error::NamespaceError(err_msg));
             }
 
-            if nix::unistd::unlink(ns_path).is_err() {
+            if nix::unistd::unlink(&netns_path).is_err() {
                 let err_msg = String::from(
                     "Namespace file remove failed (are you running as root?)",
                 );
@@ -150,7 +150,7 @@ impl NetworkNamespace {
         }
     }
 
-    fn child_process(ns_name: String) -> ! {
+    fn child_process(ns_name: &str) -> ! {
         let res = std::panic::catch_unwind(|| -> Result<(), Error> {
             let netns_path =
                 NetworkNamespace::child_process_create_ns(ns_name)?;
@@ -174,10 +174,12 @@ impl NetworkNamespace {
     /// This is the child process, it will actually create the namespace
     /// resources. It creates the folder and namespace file.
     /// Returns the namespace file path
-    pub fn child_process_create_ns(ns_name: String) -> Result<String, Error> {
+    pub fn child_process_create_ns(
+        ns_name: impl Into<String>,
+    ) -> Result<String, Error> {
         log::trace!("child_process will create the namespace");
 
-        let mut netns_path = String::new();
+        let netns_path = format!("{NETNS_PATH}{}", ns_name.into());
 
         let dir_path = Path::new(NETNS_PATH);
         let mut mkdir_mode = Mode::empty();
@@ -196,9 +198,6 @@ impl NetworkNamespace {
         open_flags.insert(OFlag::O_RDONLY);
         open_flags.insert(OFlag::O_CREAT);
         open_flags.insert(OFlag::O_EXCL);
-
-        netns_path.push_str(NETNS_PATH);
-        netns_path.push_str(&ns_name);
 
         // creating namespaces folder if not exists
         #[allow(clippy::collapsible_if)]
@@ -281,10 +280,12 @@ impl NetworkNamespace {
     /// This function unshare the calling process and move into
     /// the given network namespace
     #[allow(unused)]
-    pub fn unshare_processing(netns_path: String) -> Result<(), Error> {
+    pub fn unshare_processing(
+        netns_path: impl AsRef<Path>,
+    ) -> Result<(), Error> {
         let mut setns_flags = CloneFlags::empty();
         let mut open_flags = OFlag::empty();
-        let ns_path = Path::new(&netns_path);
+        let ns_path = netns_path.as_ref();
 
         let none_fs = Path::new(&NONE_FS);
         let none_p4: Option<&Path> = None;

--- a/src/rule/add.rs
+++ b/src/rule/add.rs
@@ -44,14 +44,18 @@ impl<T> RuleAddRequest<T> {
     }
 
     /// Sets the input interface name.
-    pub fn input_interface(mut self, ifname: String) -> Self {
-        self.message.attributes.push(RuleAttribute::Iifname(ifname));
+    pub fn input_interface(mut self, ifname: impl Into<String>) -> Self {
+        self.message
+            .attributes
+            .push(RuleAttribute::Iifname(ifname.into()));
         self
     }
 
     /// Sets the output interface name.
-    pub fn output_interface(mut self, ifname: String) -> Self {
-        self.message.attributes.push(RuleAttribute::Oifname(ifname));
+    pub fn output_interface(mut self, ifname: impl Into<String>) -> Self {
+        self.message
+            .attributes
+            .push(RuleAttribute::Oifname(ifname.into()));
         self
     }
 


### PR DESCRIPTION
The API exclusively accepted `String` parameters before. This is forcing an unergonomic API for users by forcing them to allocate a `String` for an internal detail.

This PR changes all APIs that previously accept `String` into generic `impl Into<String>` or `impl AsRef<Path>`. These changes are backwards compatible as `String` implements both of these trait bounds. 

The only  breaking change is converting the return type of `child_process_create_ns` in `ns.rs` to `Result<PathBuf, Error>`. This is more accurate to what should be returned as it is returning a file path. However, I am also wondering why this function is exposed as public while its wrapping function `child_process` is not.