### PR TITLE
Fix FreeBSD builds by gating LinkBridgeVlan and Mpls code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,12 @@ mod traffic_control;
 
 #[cfg(feature = "tokio_socket")]
 pub use crate::connection::{new_connection, new_multicast_connection};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "fuchsia",
+    target_os = "android"
+))]
+pub use crate::link::LinkBridgeVlan;
 #[cfg(not(target_os = "freebsd"))]
 pub use crate::ns::{NetworkNamespace, NETNS_PATH, NONE_FS, SELF_NS_PATH};
 #[cfg(not(target_os = "freebsd"))]
@@ -50,11 +56,10 @@ pub use crate::{
     handle::Handle,
     link::{
         LinkAddRequest, LinkBond, LinkBondPort, LinkBridge, LinkBridgePort,
-        LinkBridgeVlan, LinkDelPropRequest, LinkDelRequest, LinkDummy,
-        LinkGetRequest, LinkHandle, LinkMacSec, LinkMacVlan, LinkMacVtap,
-        LinkMessageBuilder, LinkNetkit, LinkSetRequest, LinkUnspec, LinkVeth,
-        LinkVlan, LinkVrf, LinkVxcan, LinkVxlan, LinkWireguard, LinkXfrm,
-        QosMapping,
+        LinkDelPropRequest, LinkDelRequest, LinkDummy, LinkGetRequest,
+        LinkHandle, LinkMacSec, LinkMacVlan, LinkMacVtap, LinkMessageBuilder,
+        LinkNetkit, LinkSetRequest, LinkUnspec, LinkVeth, LinkVlan, LinkVrf,
+        LinkVxcan, LinkVxlan, LinkWireguard, LinkXfrm, QosMapping,
     },
     multicast::MulticastGroup,
     neighbour::{

--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -5,7 +5,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "freebsd")))]
 use netlink_packet_route::route::{
     MplsLabel, RouteLwEnCapType, RouteLwTunnelEncap, RouteMplsIpTunnel,
     RouteSeg6IpTunnel, Seg6Header, Seg6Mode,
@@ -65,7 +65,7 @@ impl<T> RouteMessageBuilder<T> {
     }
 
     /// Sets the output MPLS encapsulation labels.
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
     pub fn output_mpls(mut self, labels: Vec<MplsLabel>) -> Self {
         if labels.is_empty() {
             return self;
@@ -481,7 +481,7 @@ impl Default for RouteMessageBuilder<IpAddr> {
     }
 }
 
-#[cfg(not(target_os = "android"))]
+#[cfg(not(any(target_os = "android", target_os = "freebsd")))]
 impl RouteMessageBuilder<MplsLabel> {
     /// Create default RouteMessage with header set to:
     ///  * route: [RouteHeader::RT_TABLE_MAIN]
@@ -498,7 +498,6 @@ impl RouteMessageBuilder<MplsLabel> {
         builder
     }
 
-    #[cfg(not(target_os = "android"))]
     /// Sets the destination MPLS label.
     pub fn label(mut self, label: MplsLabel) -> Self {
         self.message.header.address_family = AddressFamily::Mpls;
@@ -517,7 +516,8 @@ impl RouteMessageBuilder<MplsLabel> {
         self
     }
 }
-#[cfg(not(target_os = "android"))]
+
+#[cfg(not(any(target_os = "android", target_os = "freebsd")))]
 impl Default for RouteMessageBuilder<MplsLabel> {
     fn default() -> Self {
         Self::new()
@@ -565,7 +565,7 @@ impl RouteNextHopBuilder {
             (AddressFamily::Inet, IpAddr::V6(v6)) => {
                 RouteAttribute::Via(RouteVia::Inet6(v6))
             }
-            #[cfg(not(target_os = "android"))]
+            #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
             (AddressFamily::Mpls, _) => RouteAttribute::Via(addr.into()),
             (af, _) => return Err(InvalidRouteMessage::AddressFamily(af)),
         };
@@ -583,7 +583,7 @@ impl RouteNextHopBuilder {
     }
 
     /// Sets the nexthop MPLS encapsulation labels.
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
     pub fn mpls(mut self, labels: Vec<MplsLabel>) -> Self {
         if labels.is_empty() {
             return self;


### PR DESCRIPTION
LinkBridgeVlan was unconditionally imported in lib.rs but only
defined on linux/fuchsia/android. Mpls code used AddressFamily::Mpls
which doesn't exist on FreeBSD. Added cfg gates to exclude both
on FreeBSD.

Resolves: https://github.com/rust-netlink/rtnetlink/issues/154