### PR TITLE
Bump thiserror to 2 and MSRV to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ smol_socket = ["netlink-proto/smol_socket", "async-global-executor"]
 futures-util = "0.3.11"
 futures-channel = "0.3.11"
 log = "0.4.8"
-thiserror = "1"
+thiserror = "2"
 netlink-sys = { version = "0.8" }
 netlink-packet-route = { version = "0.30" }
 netlink-packet-core = { version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/rust-netlink/rtnetlink"
 description = "manipulate linux networking resources via netlink"
-rust-version = "1.66.1"
+rust-version = "1.70"
 
 [features]
 test_as_root = []


### PR DESCRIPTION
None of the breaking changes from `thiserror` should affect this crate:

https://github.com/dtolnay/thiserror/releases/tag/2.0.0

The release has been out for 1.5 years, so it should be safe to upgrade!