### PR TITLE
link: vxlan: add localbypass support

### DIFF
--- a/src/link/vxlan.rs
+++ b/src/link/vxlan.rs
@@ -229,6 +229,14 @@ impl LinkMessageBuilder<LinkVxlan> {
         self.append_info_data(InfoVxlan::CollectMetadata(collect_metadata))
     }
 
+    // Adds the `localbypass` attribute to the VXLAN
+    /// This is equivalent to `ip link add name NAME type vxlan id VNI
+    /// [no]localbypass`. \[no\]localbypass - specifies if the VXLAN
+    /// localbypass mode is turned on.
+    pub fn localbypass(self, localbypass: bool) -> Self {
+        self.append_info_data(InfoVxlan::Localbypass(localbypass))
+    }
+
     // Adds the `udp_csum` attribute to the VXLAN
     /// This is equivalent to `ip link add name NAME type vxlan id VNI
     /// [no]udp_csum`. \[no\]udpcsum - specifies if UDP checksum is


### PR DESCRIPTION
Intrduced support for the VXLAN localbypass attribute, which controls
whether the VXLAN localbypass mode is turned on.

This is equivalent to `ip link add name NAME type vxlan id VNI
[no]localbypass`.