### PR TITLE
link: add mcast_hash_elasticity method to LinkBridge builder

### DIFF
--- a/src/link/bridge.rs
+++ b/src/link/bridge.rs
@@ -180,6 +180,10 @@ impl LinkMessageBuilder<LinkBridge> {
         self.append_info_data(InfoBridge::MulticastQuerier(value))
     }
 
+    pub fn mcast_hash_elasticity(self, value: u32) -> Self {
+        self.append_info_data(InfoBridge::MulticastHashElasticity(value))
+    }
+
     pub fn mcast_hash_max(self, value: u32) -> Self {
         self.append_info_data(InfoBridge::MulticastHashMax(value))
     }


### PR DESCRIPTION
Add dedicated `mcast_hash_elasticity()` builder method for setting
`IFLA_BR_MCAST_HASH_ELASTICITY` on bridge interfaces