### PR TITLE
link: ip6tnl: Fix flow_info and flag handling

### DIFF
--- a/src/link/bond.rs
+++ b/src/link/bond.rs
@@ -42,7 +42,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkBond> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkBond;
 
 impl LinkBond {

--- a/src/link/bond_port.rs
+++ b/src/link/bond_port.rs
@@ -5,7 +5,7 @@ use crate::{
     LinkMessageBuilder,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkBondPort;
 
 impl LinkBondPort {

--- a/src/link/bridge.rs
+++ b/src/link/bridge.rs
@@ -28,21 +28,48 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkBridge> for more detail.
-#[derive(Debug)]
-pub struct LinkBridge;
+#[derive(Default, Debug)]
+pub struct LinkBridge {
+    boolopt: Option<BridgeBooleanOptions>,
+}
 
 impl LinkBridge {
     /// Equal to `LinkMessageBuilder::<LinkBridge>::new().up()`
     pub fn new(name: &str) -> LinkMessageBuilder<Self> {
         LinkMessageBuilder::<LinkBridge>::new(name).up()
     }
+
+    pub(crate) fn pre_build_info_data_process(
+        &self,
+        info_data: &mut Option<InfoData>,
+    ) {
+        let Some(boolopt) = self.boolopt else {
+            return;
+        };
+        if boolopt.mask == BridgeBooleanOptionFlags::empty() {
+            return;
+        }
+        let InfoData::Bridge(infos) =
+            info_data.get_or_insert_with(|| InfoData::Bridge(Vec::new()))
+        else {
+            log::error!("BUG: InfoData is not Bridge when processing bridge");
+            return;
+        };
+        infos.push(InfoBridge::MultiBoolOpt(boolopt));
+    }
 }
 
 impl LinkMessageBuilder<LinkBridge> {
     /// Create [LinkMessageBuilder] for linux bridge
     pub fn new(name: &str) -> Self {
-        LinkMessageBuilder::<LinkBridge>::new_with_info_kind(InfoKind::Bridge)
-            .name(name.to_string())
+        let mut builder = LinkMessageBuilder::<LinkBridge>::new_with_info_kind(
+            InfoKind::Bridge,
+        )
+        .name(name.to_string());
+        builder.set_pre_build_info_data_func(
+            LinkBridge::pre_build_info_data_process,
+        );
+        builder
     }
 
     pub fn append_info_data(self, info: InfoBridge) -> Self {
@@ -57,36 +84,19 @@ impl LinkMessageBuilder<LinkBridge> {
     }
 
     pub fn set_boolean_opt(
-        self,
+        mut self,
         opt: BridgeBooleanOptionFlags,
         value: bool,
     ) -> Self {
-        let mut ret = self;
-        if let InfoData::Bridge(infos) = ret
-            .info_data
-            .get_or_insert_with(|| InfoData::Bridge(Vec::new()))
-        {
-            let mut found = false;
-            for info in infos.iter_mut() {
-                if let InfoBridge::MultiBoolOpt(opts) = info {
-                    found = true;
-                    opts.value.set(opt, value);
-                    opts.mask.set(opt, true);
-                    break;
-                }
+        let opts = self.iface_self.boolopt.get_or_insert_with(|| {
+            BridgeBooleanOptions {
+                value: BridgeBooleanOptionFlags::empty(),
+                mask: BridgeBooleanOptionFlags::empty(),
             }
-            if !found {
-                infos.push(InfoBridge::MultiBoolOpt(BridgeBooleanOptions {
-                    value: if value {
-                        opt
-                    } else {
-                        BridgeBooleanOptionFlags::empty()
-                    },
-                    mask: opt,
-                }));
-            }
-        }
-        ret
+        });
+        opts.value.set(opt, value);
+        opts.mask.set(opt, true);
+        self
     }
 
     pub fn ageing_time(self, value: u32) -> Self {

--- a/src/link/bridge_port.rs
+++ b/src/link/bridge_port.rs
@@ -8,7 +8,7 @@ use crate::{
     LinkMessageBuilder,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkBridgePort;
 
 impl LinkBridgePort {

--- a/src/link/bridge_vlan.rs
+++ b/src/link/bridge_vlan.rs
@@ -11,7 +11,7 @@ use crate::{
     LinkMessageBuilder,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkBridgeVlan;
 
 impl LinkBridgeVlan {

--- a/src/link/builder.rs
+++ b/src/link/builder.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use std::{marker::PhantomData, os::fd::RawFd};
+use std::os::fd::RawFd;
 
 use crate::packet_route::{
     link::{
@@ -35,7 +35,7 @@ use crate::packet_route::{
 ///         .map_err(|e| format!("{e}"))
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkUnspec;
 
 impl LinkUnspec {
@@ -61,10 +61,11 @@ pub struct LinkMessageBuilder<T> {
     pub(crate) port_kind: Option<InfoPortKind>,
     pub(crate) port_data: Option<InfoPortData>,
     pub(crate) extra_attriutes: Vec<LinkAttribute>,
-    _phantom: PhantomData<T>,
+    pre_build_info_data_process_fn: Option<fn(&T, &mut Option<InfoData>)>,
+    pub(crate) iface_self: T,
 }
 
-impl<T> Default for LinkMessageBuilder<T> {
+impl<T: Default> Default for LinkMessageBuilder<T> {
     fn default() -> Self {
         Self {
             header: Default::default(),
@@ -73,17 +74,27 @@ impl<T> Default for LinkMessageBuilder<T> {
             extra_attriutes: Default::default(),
             port_kind: None,
             port_data: None,
-            _phantom: Default::default(),
+            pre_build_info_data_process_fn: None,
+            iface_self: T::default(),
         }
     }
 }
 
-impl<T> LinkMessageBuilder<T> {
+impl<T: Default> LinkMessageBuilder<T> {
     pub fn new_with_info_kind(info_kind: InfoKind) -> Self {
         Self {
             info_kind: Some(info_kind),
             ..Default::default()
         }
+    }
+}
+
+impl<T> LinkMessageBuilder<T> {
+    pub fn set_pre_build_info_data_func(
+        &mut self,
+        f: fn(&T, &mut Option<InfoData>),
+    ) {
+        self.pre_build_info_data_process_fn = Some(f);
     }
 
     /// Set arbitrary [LinkHeader]
@@ -236,7 +247,12 @@ impl<T> LinkMessageBuilder<T> {
         if let Some(info_kind) = self.info_kind {
             link_infos.push(LinkInfo::Kind(info_kind));
         }
-        if let Some(info_data) = self.info_data {
+
+        let mut info_data = self.info_data;
+        if let Some(pre_build_fn) = self.pre_build_info_data_process_fn {
+            pre_build_fn(&self.iface_self, &mut info_data);
+        }
+        if let Some(info_data) = info_data {
             link_infos.push(LinkInfo::Data(info_data));
         }
 

--- a/src/link/dummy.rs
+++ b/src/link/dummy.rs
@@ -21,7 +21,7 @@ use crate::{link::LinkMessageBuilder, packet_route::link::InfoKind};
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkDummy> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkDummy;
 
 impl LinkDummy {

--- a/src/link/hsr.rs
+++ b/src/link/hsr.rs
@@ -30,7 +30,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkHsr> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkHsr;
 
 impl LinkHsr {

--- a/src/link/ip6tnl.rs
+++ b/src/link/ip6tnl.rs
@@ -13,6 +13,9 @@ use crate::{
     LinkMessageBuilder,
 };
 
+const IP6_FLOWINFO_TCLASS_MASK: u32 = 0x0ff00000;
+const IP6_FLOWINFO_FLOWLABEL_MASK: u32 = 0x000fffff;
+
 /// Represent IP6TNL interface.
 /// Example code on creating a IP6TNL interface
 /// ```no_run
@@ -38,21 +41,59 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkIp6Tnl> for more detail.
-#[derive(Debug)]
-pub struct LinkIp6Tnl;
+#[derive(Default, Debug)]
+pub struct LinkIp6Tnl {
+    flags: Option<Ip6TunnelFlags>,
+    flowinfo: Option<u32>,
+}
 
 impl LinkIp6Tnl {
     /// Equal to `LinkMessageBuilder::<LinkIp6Tnl>::new()`
     pub fn new(name: &str) -> LinkMessageBuilder<Self> {
         LinkMessageBuilder::<LinkIp6Tnl>::new(name)
     }
+
+    fn get_flags_mut(&mut self) -> &mut Ip6TunnelFlags {
+        self.flags.get_or_insert(Ip6TunnelFlags::empty())
+    }
+
+    fn get_flowinfo_mut(&mut self) -> &mut u32 {
+        self.flowinfo.get_or_insert(0)
+    }
+
+    pub(crate) fn pre_build_info_data_process(
+        &self,
+        info_data: &mut Option<InfoData>,
+    ) {
+        if self.flowinfo.is_none() && self.flags.is_none() {
+            return;
+        }
+        let InfoData::IpTunnel(infos) =
+            info_data.get_or_insert_with(|| InfoData::IpTunnel(Vec::new()))
+        else {
+            log::error!("BUG: InfoData is not IpTunnel when processing ip6tnl");
+            return;
+        };
+        if let Some(flowinfo) = self.flowinfo {
+            infos.push(InfoIpTunnel::FlowInfo(flowinfo));
+        }
+        if let Some(flags) = self.flags {
+            infos.push(InfoIpTunnel::Ipv6Flags(flags));
+        }
+    }
 }
 
 impl LinkMessageBuilder<LinkIp6Tnl> {
     /// Create [LinkMessageBuilder] for IP6TNL
     pub fn new(name: &str) -> Self {
-        LinkMessageBuilder::<LinkIp6Tnl>::new_with_info_kind(InfoKind::Ip6Tnl)
-            .name(name.to_string())
+        let mut builder = LinkMessageBuilder::<LinkIp6Tnl>::new_with_info_kind(
+            InfoKind::Ip6Tnl,
+        )
+        .name(name.to_string());
+        builder.set_pre_build_info_data_func(
+            LinkIp6Tnl::pre_build_info_data_process,
+        );
+        builder
     }
 
     fn append_info_data(self, info: InfoIpTunnel) -> Self {
@@ -84,28 +125,85 @@ impl LinkMessageBuilder<LinkIp6Tnl> {
         self.append_info_data(InfoIpTunnel::Ttl(ttl))
     }
 
-    /// This is equivalent to `tos TOS` in command
-    /// `ip link add name NAME type ip6tnl tos TOS`.
-    pub fn tos(self, tos: u8) -> Self {
-        self.append_info_data(InfoIpTunnel::Tos(tos))
-    }
-
     /// This is equivalent to `encaplimit LIMIT` in command
     /// `ip link add name NAME type ip6tnl encaplimit LIMIT`.
     pub fn encap_limit(self, limit: u8) -> Self {
         self.append_info_data(InfoIpTunnel::EncapLimit(limit))
     }
 
-    /// This is equivalent to `flowlabel LABEL` in command
-    /// `ip link add name NAME type ip6tnl flowlabel LABEL`.
-    pub fn flowlabel(self, flowlabel: u32) -> Self {
-        self.append_info_data(InfoIpTunnel::FlowInfo(flowlabel))
+    /// Set the traffic class value.
+    ///
+    /// `val` is the 8-bit traffic class value.
+    /// When `Some`, the tclass bits are set and `UseOrigTclass` flag is
+    /// cleared. When `None`, the `UseOrigTclass` flag is set (inherit).
+    pub fn tclass(mut self, val: Option<u8>) -> Self {
+        match val {
+            Some(v) => {
+                let flowinfo = self.iface_self.get_flowinfo_mut();
+                *flowinfo = (*flowinfo & !IP6_FLOWINFO_TCLASS_MASK)
+                    | ((v as u32) << 20);
+                let f = self.iface_self.get_flags_mut();
+                *f &= !Ip6TunnelFlags::UseOrigTclass;
+            }
+            None => {
+                let f = self.iface_self.get_flags_mut();
+                *f |= Ip6TunnelFlags::UseOrigTclass;
+            }
+        }
+        self
+    }
+
+    /// Set the flow label value.
+    ///
+    /// `val` is the 20-bit flow label value.
+    /// When `Some`, the flowlabel bits are set and `UseOrigFlowlabel` flag
+    /// is cleared. When `None`, the `UseOrigFlowlabel` flag is set (inherit).
+    /// Values exceeding 20 bits are ignored with a warning logged.
+    pub fn flowlabel(mut self, val: Option<u32>) -> Self {
+        match val {
+            Some(v) => {
+                if v > 0xfffff {
+                    log::error!(
+                        "flowlabel value {v:#x} exceeds 20 bits \
+                        (max 0xFFFFF), ignoring"
+                    );
+                    return self;
+                }
+                let flowinfo = self.iface_self.get_flowinfo_mut();
+                *flowinfo = (*flowinfo & !IP6_FLOWINFO_FLOWLABEL_MASK)
+                    | (v & IP6_FLOWINFO_FLOWLABEL_MASK);
+                let f = self.iface_self.get_flags_mut();
+                *f &= !Ip6TunnelFlags::UseOrigFlowlabel;
+            }
+            None => {
+                let f = self.iface_self.get_flags_mut();
+                *f |= Ip6TunnelFlags::UseOrigFlowlabel;
+            }
+        }
+        self
+    }
+
+    /// Set or clear an ip6 tunnel flag
+    pub fn set_flag(mut self, flag: Ip6TunnelFlags, enabled: bool) -> Self {
+        let f = self.iface_self.get_flags_mut();
+        if enabled {
+            *f |= flag;
+        } else {
+            *f &= !flag;
+        }
+        self
     }
 
     /// This is equivalent to `mode MODE` in command
     /// `ip link add name NAME type ip6tnl mode MODE`.
     pub fn protocol(self, proto: IpProtocol) -> Self {
         self.append_info_data(InfoIpTunnel::Protocol(proto))
+    }
+
+    /// This is equivalent to `mode MODE` in command
+    /// `ip link add name NAME type ip6tnl mode MODE`.
+    pub fn mode(self, mode: IpProtocol) -> Self {
+        self.protocol(mode)
     }
 
     /// This is equivalent to `[no]pmtudisc` in command
@@ -137,11 +235,6 @@ impl LinkMessageBuilder<LinkIp6Tnl> {
         self.append_info_data(InfoIpTunnel::FwMark(mark))
     }
 
-    /// Set IP6 tunnel flags
-    pub fn ip6_flags(self, flags: Ip6TunnelFlags) -> Self {
-        self.append_info_data(InfoIpTunnel::Ipv6Flags(flags))
-    }
-
     /// This is equivalent to `encap { fou | gue | none }` in command
     /// `ip link add name NAME type ip6tnl encap TYPE`.
     pub fn encap_type(self, encap_type: TunnelEncapType) -> Self {
@@ -164,5 +257,17 @@ impl LinkMessageBuilder<LinkIp6Tnl> {
     /// `ip link add name NAME type ip6tnl encap-csum`.
     pub fn encap_flags(self, flags: TunnelEncapFlags) -> Self {
         self.append_info_data(InfoIpTunnel::EncapFlags(flags))
+    }
+
+    /// Set arbitrary [InfoIpTunnel::Ipv6Flags]
+    pub fn ipv6_flags(mut self, flags: Ip6TunnelFlags) -> Self {
+        self.iface_self.flags = Some(flags);
+        self
+    }
+
+    /// Set arbitrary [InfoIpTunnel::FlowInfo]
+    pub fn flowinfo_raw(mut self, flowinfo: u32) -> Self {
+        self.iface_self.flowinfo = Some(flowinfo);
+        self
     }
 }

--- a/src/link/iptun.rs
+++ b/src/link/iptun.rs
@@ -35,7 +35,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkIpIp> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkIpIp;
 
 impl LinkIpIp {

--- a/src/link/mac_vlan.rs
+++ b/src/link/mac_vlan.rs
@@ -30,7 +30,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkMacVlan> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkMacVlan;
 
 impl LinkMacVlan {

--- a/src/link/mac_vtap.rs
+++ b/src/link/mac_vtap.rs
@@ -30,7 +30,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkMacVtap> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkMacVtap;
 
 impl LinkMacVtap {

--- a/src/link/macsec.rs
+++ b/src/link/macsec.rs
@@ -34,7 +34,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkMacSec> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkMacSec;
 
 impl LinkMacSec {

--- a/src/link/netkit.rs
+++ b/src/link/netkit.rs
@@ -7,7 +7,7 @@ use crate::{
     LinkMessageBuilder, LinkUnspec,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 /// Represent netkit virtual interface.
 /// Netkit devices are used for container networking and BPF programs.
 ///

--- a/src/link/nlmon.rs
+++ b/src/link/nlmon.rs
@@ -19,7 +19,7 @@ use crate::{link::LinkMessageBuilder, packet_route::link::InfoKind};
 ///         .map_err(|e| format!("{e}"))
 /// }
 /// ```
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkNlmon;
 
 impl LinkNlmon {

--- a/src/link/veth.rs
+++ b/src/link/veth.rs
@@ -5,7 +5,7 @@ use crate::{
     LinkMessageBuilder, LinkUnspec,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 /// Represent virtual ethernet interface.
 /// Example code on creating a veth pair
 /// ```no_run

--- a/src/link/vlan.rs
+++ b/src/link/vlan.rs
@@ -44,7 +44,7 @@ impl From<QosMapping> for VlanQosMapping {
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkVlan> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkVlan;
 
 impl LinkVlan {

--- a/src/link/vrf.rs
+++ b/src/link/vrf.rs
@@ -28,7 +28,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkVrf> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkVrf;
 
 impl LinkVrf {

--- a/src/link/vxcan.rs
+++ b/src/link/vxcan.rs
@@ -24,7 +24,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkVxcan> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkVxcan;
 
 impl LinkVxcan {

--- a/src/link/vxlan.rs
+++ b/src/link/vxlan.rs
@@ -28,7 +28,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkVlan> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkVxlan;
 
 impl LinkVxlan {

--- a/src/link/wireguard.rs
+++ b/src/link/wireguard.rs
@@ -21,7 +21,7 @@ use crate::{link::LinkMessageBuilder, packet_route::link::InfoKind};
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkWireguard> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkWireguard;
 
 impl LinkWireguard {

--- a/src/link/xfrm.rs
+++ b/src/link/xfrm.rs
@@ -24,7 +24,7 @@ use crate::{
 /// ```
 ///
 /// Please check LinkMessageBuilder::<LinkXfrm> for more detail.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct LinkXfrm;
 
 impl LinkXfrm {


### PR DESCRIPTION
This patch also introduce new design into `LinkMessageBuilder` allowing
interface specific builder to modify `InfoData` before it been appended
into `LinkMessage` during `build()` process.

Check `pre_build_info_data_process()` for more detail.