### PR TITLE
New release 0.22.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,23 @@
 # Changelog
+## [0.22.0] - 2026-06-23
+### Breaking changes
+ - Use netlink-packet-route 0.31.0. (ceb2aff)
+ - Migrate to more permissive/accurate string types. (0c42c83)
+ - Replace function on `NeighbourGetRequest` to set family. (97dd4ca)
+ - Bump minimum supported Rust version to 1.71. (3041a35)
+
+### New features
+ - link: Add `LinkIp6Tnl` builder for IPv4/IPv6 tunnel over IPv6. (908fa90)
+ - link: vxlan: Add builder functions for label_policy, reserved_bits, and mc_route. (616450a)
+ - link: Add IPIP message builder. (e92b23f)
+ - link: Add HSR interface support. (f1fb864)
+ - link: vxlan: Add localbypass support. (cf0a5c8)
+ - link: Add nlmon support. (9b4536a)
+ - Add API for Seg6 encapsulation. (e48d718)
+
+### Bug fixes
+ - link: ip6tnl: Fix flow_info and flag handling. (e7799b6)
+
 ## [0.21.0] - 2026-04-18
 ### Breaking changes
  - Use netlink-packet-route 0.30. (7bfbbf5)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtnetlink"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Corentin Henry <corentinhenry@gmail.com>"]
 edition = "2021"
 homepage = "https://github.com/rust-netlink/rtnetlink"


### PR DESCRIPTION
## Summary

Prepares a `0.22.0` release: bumps the crate version `0.21.0 → 0.22.0` and adds a CHANGELOG section for the changes already merged to `main` since `0.21.0`. No code changes.

## Why I'm opening this

I maintain [rustbgpd](https://github.com/lance0/rustbgpd), a Rust BGP daemon with an EVPN/VXLAN Linux dataplane that creates and reconciles netdevs — bridges, VXLANs, VRFs, L3VXLANs, VLAN sub-interfaces, and collect-metadata "single VXLAN device" setups with bridge VLAN→VNI tunnel mappings — through `rtnetlink`. That work depends on `netlink-packet-route` 0.31 types (e.g. the `InfoVxlan::Df` enum and the `InfoIpTunnel::CollectMetadata` change).

`main` already moved to `netlink-packet-route 0.31.0` (ceb2aff), but the latest crates.io release (`0.21.0`) still pins `0.30`. So adopting 0.31 today means a `[patch.crates-io]` git pin to an unreleased commit. A published `0.22.0` would let us — and any other downstream wanting 0.31 — drop the pin and take a normal version bump.

## Totally your call

This is just the version + CHANGELOG legwork to make a release easy; please treat it as a nudge, not a request to merge as-is. If you'd rather close it and cut the release yourself, batch in other pending PRs first, or adjust the version number / changelog wording, that's completely fine. The crates.io publish is of course yours.

CHANGELOG entries are derived from `git log v0.21.0..main` (I left out the internal `thiserror` bump to match the existing convention). Verified locally: `cargo build --all-targets` and `cargo fmt --check` clean. Thanks for maintaining rtnetlink!
