### PR TITLE
link: gre6: add dev() builder method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-channel = "0.3.11"
 log = "0.4.8"
 thiserror = "2"
 netlink-sys = { version = "0.8" }
-netlink-packet-route = { version = "0.32.0" }
+netlink-packet-route = { version = "0.32.1" }
 netlink-packet-core = { version = "0.8" }
 netlink-proto = { default-features = false, version = "0.12.0" }
 nix = { version = "0.30.0", default-features = false, features = ["fs", "mount", "sched", "signal"] }

--- a/src/link/gre6.rs
+++ b/src/link/gre6.rs
@@ -61,6 +61,10 @@ impl LinkMessageBuilder<LinkGre6> {
         ret
     }
 
+    pub fn dev(self, ifindex: u32) -> Self {
+        self.append_info_data(InfoGre6::Link(ifindex))
+    }
+
     pub fn local(self, addr: Ipv6Addr) -> Self {
         self.append_info_data(InfoGre6::Local(addr))
     }


### PR DESCRIPTION
Add LinkMessageBuilder<LinkGre6>::dev() to set IFLA_GRE_LINK attribute.